### PR TITLE
feat: Cart domain entity, repository 구현

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/entity/Cart.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/entity/Cart.java
@@ -1,0 +1,50 @@
+package com.spartafarmer.agri_commerce.domain.cart.entity;
+
+import com.spartafarmer.agri_commerce.common.entity.BaseEntity;
+import com.spartafarmer.agri_commerce.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "carts")
+public class Cart extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Getter(AccessLevel.NONE)
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL)
+    private List<CartItem> cartItems = new ArrayList<>();
+
+    private Cart(User user) {
+        this.user = user;
+    }
+
+    // 장바구니 생성
+    public static Cart create(User user) {
+        return new Cart(user);
+    }
+
+    // 장바구니 상품 목록 조회 (읽기 전용)
+    public List<CartItem> getCartItems() {
+        return Collections.unmodifiableList(cartItems);
+    }
+
+    // 장바구니 상품 추가
+    public void addCartItem(CartItem cartItem) {
+        this.cartItems.add(cartItem);
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/entity/CartItem.java
@@ -1,0 +1,61 @@
+package com.spartafarmer.agri_commerce.domain.cart.entity;
+
+import com.spartafarmer.agri_commerce.common.entity.BaseEntity;
+import com.spartafarmer.agri_commerce.domain.product.entity.Product;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "cart_items")
+@SQLDelete(sql = "UPDATE cart_items SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
+public class CartItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id", nullable = false)
+    private Cart cart;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(nullable = false)
+    private Long price;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    private CartItem(Cart cart, Product product, Long price, int quantity) {
+        this.cart = cart;
+        this.product = product;
+        this.price = price;
+        this.quantity = quantity;
+    }
+
+    // 장바구니 상품 생성 및 장바구니에 추가
+    public static CartItem create(Cart cart, Product product, Long price, int quantity) {
+        CartItem item = new CartItem(cart, product, price, quantity);
+        cart.addCartItem(item);
+        return item;
+    }
+
+    // 수량 변경
+    public void updateQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/repository/CartItemRepository.java
@@ -1,0 +1,18 @@
+package com.spartafarmer.agri_commerce.domain.cart.repository;
+
+import com.spartafarmer.agri_commerce.domain.cart.entity.Cart;
+import com.spartafarmer.agri_commerce.domain.cart.entity.CartItem;
+import com.spartafarmer.agri_commerce.domain.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+
+    // @Where로 deleted_at IS NULL 자동 적용됨
+    List<CartItem> findByCart(Cart cart);
+
+    // productId → product으로 변경
+    Optional<CartItem> findByCartAndProduct(Cart cart, Product product);
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/repository/CartRepository.java
@@ -1,0 +1,12 @@
+package com.spartafarmer.agri_commerce.domain.cart.repository;
+
+import com.spartafarmer.agri_commerce.domain.cart.entity.Cart;
+import com.spartafarmer.agri_commerce.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+
+    Optional<Cart> findByUser(User user);
+}


### PR DESCRIPTION
📌 작업 내용- 어떤 작업인지 한 줄로 설명
Cart, CartItem Entity/Repository 구현

🔗 관련 이슈- close #28 


🧩 변경 사항- 주요 변경 내용
* Cart Entity 구현
* CartItem Entity 구현
* CartRepository 구현
* CartItemRepository 구현
* Cart, CartItem 연관 관계 설정 (Cart 1 : N CartItem)
* CartItem → Product 직접 참조 (@ManyToOne)


🧪 테스트
~~- [ ] Postman 1차 테스트 완료 (서비스/컨트롤러 구현 후 진행 예정)~~

~~- [ ] 단위 테스트 완료 (해당 시)~~


🔥 리뷰 요청&기타
- ERD CART 테이블 status 컬럼 제거 반영 필요(정책/명세에서 사용되는 곳이 없어 제거 필요하다고 생각)


## 💡 구현 포인트
### ✅ 소프트 딜리트 @SQLDelete + @Where 적용
- `@SQLDelete` 로 delete() 호출 시 DELETE 대신 UPDATE 쿼리로 자동 변환
- `@Where` 로 영속성 컨텍스트 단에서부터 삭제된 항목 자동 제외
- Repository 메서드에서 `DeletedAtIsNull` 조건 명시 불필요

**장점**
- `Cart.cartItems` 연관관계 조회 시 삭제된 항목 자동 제외
- Repository 메서드 이름이 간결해짐

**trade-off**
- 삭제된 CartItem 조회가 전역적으로 불가능해짐
- 현재 정책상 삭제된 항목을 다시 조회할 일이 없으므로 문제없다고 판단

---

### ✅ DB 벤더 독립적인 소프트 딜리트 쿼리
- CURRENT_TIMESTAMP를 사용하여 MySQL 외 DB에서도 동작 가능하도록 개선

---

### ✅ 장바구니 상품 목록 읽기 전용 보호
- `cartItems` 컬렉션을 `unmodifiableList()` 로 래핑하여 외부에서 직접 수정 불가
- `addCartItem()` 편의 메서드를 통해서만 상품 추가 가능하도록 강제하여 양방향 연관관계 무결성 보장