### PR TITLE
feat: order domain entity, repository 구현

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/entity/Order.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/entity/Order.java
@@ -1,0 +1,74 @@
+package com.spartafarmer.agri_commerce.domain.order.entity;
+
+import com.spartafarmer.agri_commerce.common.entity.BaseEntity;
+import com.spartafarmer.agri_commerce.domain.coupon.entity.UserCoupon;
+import com.spartafarmer.agri_commerce.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "orders")
+public class Order extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // 쿠폰 미적용시 null 허용
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_coupon_id")
+    private UserCoupon coupon;
+
+    // 총 상품 금액(할인 전)
+    @Column(name = "total_price", nullable = false)
+    private Long totalPrice;
+
+    // 쿠폰 미적용 시 0
+    @Column(name = "discount_price", nullable = false)
+    private Long discountPrice;
+
+    // 최종 결제 금액(할인가격 포함)
+    @Column(name = "final_price", nullable = false)
+    private Long finalPrice;
+
+    // 주문 상태
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    // 주문 상품 목록
+    // Order 저장하면 OrderItem도 같이 저장됨
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    // 주문 생성 (성공한 경우만 생성됨)
+    // 실패 - DB 저장 안됨, 성공시 COMPLETED만 존재
+    public static Order create(User user, UserCoupon coupon,
+                               Long totalPrice, Long discountPrice, Long finalPrice) {
+
+        Order order = new Order();
+        order.user = user;
+        order.coupon = coupon;
+        order.totalPrice = totalPrice;
+        order.discountPrice = discountPrice;
+        order.finalPrice = finalPrice;
+        order.status = OrderStatus.COMPLETED;
+        return order;
+    }
+
+    // 주문에 상품을 포함시키기 위한 메서드 (양방향 관계 동기화)
+    public void addOrderItem(OrderItem orderItem) {
+        this.orderItems.add(orderItem);
+        orderItem.setOrder(this);
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/entity/OrderItem.java
@@ -1,0 +1,50 @@
+package com.spartafarmer.agri_commerce.domain.order.entity;
+
+import com.spartafarmer.agri_commerce.common.entity.BaseEntity;
+import com.spartafarmer.agri_commerce.domain.product.entity.Product;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "order_items")
+public class OrderItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(nullable = false)
+    private Long price;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    private OrderItem(Product product, Long price, Integer quantity) {
+        this.product = product;
+        this.price = price;
+        this.quantity = quantity;
+    }
+
+    // 주문상품 생성 후 해당 주문(Order)에 자동으로 포함시킨다.
+    public static OrderItem create(Order order, Product product, Long price, Integer quantity) {
+        OrderItem item = new OrderItem(product, price, quantity);
+        order.addOrderItem(item);
+        return item;
+    }
+
+    void setOrder(Order order) {
+        this.order = order;
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/entity/OrderStatus.java
@@ -1,0 +1,5 @@
+package com.spartafarmer.agri_commerce.domain.order.entity;
+
+public enum OrderStatus {
+    COMPLETED, // 결제 완료(구매하기 성공시 즉시 확정)
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/repository/OrderItemRepository.java
@@ -1,0 +1,12 @@
+package com.spartafarmer.agri_commerce.domain.order.repository;
+
+import com.spartafarmer.agri_commerce.domain.order.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+
+    // 특정 주문의 주문 상품 목록 조회
+    List<OrderItem> findAllByOrderId(Long orderId);
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/repository/OrderRepository.java
@@ -1,0 +1,11 @@
+package com.spartafarmer.agri_commerce.domain.order.repository;
+
+import com.spartafarmer.agri_commerce.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    // 사용자 주문 목록 (최신순)
+    List<Order> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+}


### PR DESCRIPTION
📌 작업 내용
주문 도메인(Entity, Repository) 기본 구조 구현

🔗 관련 이슈
close #29 

🧩 변경 사항

- Order Entity 구현
- OrderItem Entity 구현
- OrderRepository 구현
- OrderItemRepository 구현
- OrderItem 생성 시 Order에 자동 포함되도록 구조 설계
- cascade 설정으로 Order 저장 시 OrderItem 함께 저장되도록 구성

💡 기타
- 주문은 성공 시에만 생성되도록 설계 (실패 시 DB 저장 없음)
- 주문 상태는 COMPLETED만 사용 (단순 구조 유지)