### PR TITLE
feat: 쿠폰 생성 API 구현(#27)

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/common/exception/ErrorCode.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/common/exception/ErrorCode.java
@@ -43,7 +43,9 @@ public enum ErrorCode {
     USER_COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "보유한 쿠폰을 찾을 수 없습니다."),
     USER_COUPON_ALREADY_USED(HttpStatus.BAD_REQUEST, "이미 사용된 쿠폰입니다."),
     USER_COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 쿠폰입니다."),
-    COUPON_NOT_APPLICABLE(HttpStatus.BAD_REQUEST, "특가 상품이 포함된 주문에는 쿠폰을 사용할 수 없습니다.");
+    COUPON_NOT_APPLICABLE(HttpStatus.BAD_REQUEST, "특가 상품이 포함된 주문에는 쿠폰을 사용할 수 없습니다."),
+    INVALID_COUPON_START_TIME(HttpStatus.BAD_REQUEST, "시작 시각은 현재 시각 이후여야 합니다."),
+    INVALID_COUPON_END_TIME(HttpStatus.BAD_REQUEST, "종료 시각은 시작 시각보다 이후여야 합니다.");
 
     // 이 코드 위쪽에 에러 코드 작성
     private final HttpStatus status;

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/controller/CouponController.java
@@ -1,0 +1,32 @@
+package com.spartafarmer.agri_commerce.domain.coupon.controller;
+
+import com.spartafarmer.agri_commerce.common.response.ApiResponse;
+import com.spartafarmer.agri_commerce.domain.coupon.dto.request.CouponCreateRequest;
+import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponCreateResponse;
+import com.spartafarmer.agri_commerce.domain.coupon.service.CouponService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coupons")
+public class CouponController {
+
+    private final CouponService couponService;
+
+    // 쿠폰 생성 (관리자)
+    @Secured("ROLE_ADMIN")
+    @PostMapping
+    public ResponseEntity<ApiResponse<CouponCreateResponse>> createCoupon(
+            @Valid @RequestBody CouponCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(201, "쿠폰이 생성되었습니다.", couponService.createCoupon(request)));
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/request/CouponCreateRequest.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/request/CouponCreateRequest.java
@@ -1,0 +1,29 @@
+package com.spartafarmer.agri_commerce.domain.coupon.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CouponCreateRequest {
+
+    @NotBlank
+    private String name;
+
+    @NotNull
+    @Min(1)
+    private Long discountAmount;
+
+    @NotNull
+    @Min(1)
+    private Integer totalQuantity;
+
+    @NotNull
+    private LocalDateTime startTime;
+
+    @NotNull
+    private LocalDateTime endTime;
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/CouponCreateResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/CouponCreateResponse.java
@@ -1,0 +1,30 @@
+package com.spartafarmer.agri_commerce.domain.coupon.dto.response;
+
+import com.spartafarmer.agri_commerce.domain.coupon.entity.Coupon;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CouponCreateResponse {
+
+    private final Long couponId;
+    private final String name;
+    private final Long discountAmount;
+    private final int totalQuantity;
+    private final LocalDateTime startTime;
+    private final LocalDateTime endTime;
+
+    private CouponCreateResponse(Coupon coupon) {
+        this.couponId = coupon.getId();
+        this.name = coupon.getName();
+        this.discountAmount = coupon.getDiscountPrice();
+        this.totalQuantity = coupon.getTotalCount();
+        this.startTime = coupon.getStartTime();
+        this.endTime = coupon.getEndTime();
+    }
+
+    public static CouponCreateResponse from(Coupon coupon) {
+        return new CouponCreateResponse(coupon);
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponService.java
@@ -1,0 +1,39 @@
+package com.spartafarmer.agri_commerce.domain.coupon.service;
+
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.domain.coupon.dto.request.CouponCreateRequest;
+import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponCreateResponse;
+import com.spartafarmer.agri_commerce.domain.coupon.entity.Coupon;
+import com.spartafarmer.agri_commerce.domain.coupon.repository.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    // 쿠폰 생성 (관리자)
+    @Transactional
+    public CouponCreateResponse createCoupon(CouponCreateRequest request) {
+
+        // 종료 시각은 시작 시각보다 이후여야 함
+        if (!request.getEndTime().isAfter(request.getStartTime())) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        Coupon coupon = Coupon.create(
+                request.getName(),
+                request.getDiscountAmount(),
+                request.getTotalQuantity(),
+                request.getStartTime(),
+                request.getEndTime()
+        );
+
+        couponRepository.save(coupon);
+        return CouponCreateResponse.from(coupon);
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class CouponService {
@@ -20,9 +22,16 @@ public class CouponService {
     @Transactional
     public CouponCreateResponse createCoupon(CouponCreateRequest request) {
 
+        LocalDateTime now = LocalDateTime.now();
+
+        // 시작 시각은 현재 이후여야 함
+        if (!request.getStartTime().isAfter(now)) {
+            throw new CustomException(ErrorCode.INVALID_COUPON_START_TIME);
+        }
+
         // 종료 시각은 시작 시각보다 이후여야 함
         if (!request.getEndTime().isAfter(request.getStartTime())) {
-            throw new CustomException(ErrorCode.INVALID_REQUEST);
+            throw new CustomException(ErrorCode.INVALID_COUPON_END_TIME);
         }
 
         Coupon coupon = Coupon.create(


### PR DESCRIPTION
📌 작업 내용
- 관리자 쿠폰 생성 API 구현

🔗 관련 이슈
- close #27

🧩 변경 사항
- CouponCreateRequest / CouponCreateResponse DTO 생성
- CouponService 쿠폰 생성 로직 구현 (종료시각 > 시작시각 검증 포함)
- CouponController 관리자 전용 엔드포인트 구현 (@Secured("ROLE_ADMIN"))

🧪 테스트
- [o] Postman 1차 테스트 완료
- [ ] 단위 테스트 완료 (해당 시)

🔥 리뷰 요청
- CouponCreateRequest에서 discountAmount로 받고 엔티티는 discountPrice인 부분, DTO↔Entity 네이밍 차이 괜찮은지 확인 부탁드립니다