### PR TITLE
Feat/coupon list api #32

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/controller/CouponController.java
@@ -1,18 +1,21 @@
 package com.spartafarmer.agri_commerce.domain.coupon.controller;
 
 import com.spartafarmer.agri_commerce.common.response.ApiResponse;
+import com.spartafarmer.agri_commerce.common.security.AuthUser;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.request.CouponCreateRequest;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponCreateResponse;
+import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponListResponse;
+import com.spartafarmer.agri_commerce.domain.coupon.dto.response.UserCouponResponse;
 import com.spartafarmer.agri_commerce.domain.coupon.service.CouponService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,5 +31,19 @@ public class CouponController {
             @Valid @RequestBody CouponCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(201, "쿠폰이 생성되었습니다.", couponService.createCoupon(request)));
+    }
+
+    // 쿠폰 전체 목록 조회 (관리자)
+    @Secured("ROLE_ADMIN")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CouponListResponse>>> getCoupons() {
+        return ResponseEntity.ok(ApiResponse.success(couponService.getCoupons()));
+    }
+
+    // 내 쿠폰 목록 조회
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<List<UserCouponResponse>>> getMyCoupons(
+            @AuthenticationPrincipal AuthUser authUser) {
+        return ResponseEntity.ok(ApiResponse.success(couponService.getMyCoupons(authUser.getId())));
     }
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/controller/CouponController.java
@@ -9,6 +9,9 @@ import com.spartafarmer.agri_commerce.domain.coupon.dto.response.UserCouponRespo
 import com.spartafarmer.agri_commerce.domain.coupon.service.CouponService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -36,8 +39,9 @@ public class CouponController {
     // 쿠폰 전체 목록 조회 (관리자)
     @Secured("ROLE_ADMIN")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<CouponListResponse>>> getCoupons() {
-        return ResponseEntity.ok(ApiResponse.success(couponService.getCoupons()));
+    public ResponseEntity<ApiResponse<Page<CouponListResponse>>> getCoupons(
+            @PageableDefault(size = 10) Pageable pageable) {
+        return ResponseEntity.ok(ApiResponse.success(couponService.getCoupons(pageable)));
     }
 
     // 내 쿠폰 목록 조회

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/CouponCreateResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/CouponCreateResponse.java
@@ -18,8 +18,8 @@ public class CouponCreateResponse {
     private CouponCreateResponse(Coupon coupon) {
         this.couponId = coupon.getId();
         this.name = coupon.getName();
-        this.discountAmount = coupon.getDiscountPrice();
-        this.totalQuantity = coupon.getTotalCount();
+        this.discountAmount = coupon.getDiscountAmount();
+        this.totalQuantity = coupon.getTotalQuantity();
         this.startTime = coupon.getStartTime();
         this.endTime = coupon.getEndTime();
     }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/CouponListResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/CouponListResponse.java
@@ -1,0 +1,32 @@
+package com.spartafarmer.agri_commerce.domain.coupon.dto.response;
+
+import com.spartafarmer.agri_commerce.domain.coupon.entity.Coupon;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CouponListResponse {
+
+    private final Long couponId;
+    private final String name;
+    private final Long discountAmount;
+    private final int totalQuantity;
+    private final int issuedQuantity;
+    private final LocalDateTime startTime;
+    private final LocalDateTime endTime;
+
+    private CouponListResponse(Coupon coupon) {
+        this.couponId = coupon.getId();
+        this.name = coupon.getName();
+        this.discountAmount = coupon.getDiscountPrice();
+        this.totalQuantity = coupon.getTotalCount();
+        this.issuedQuantity = coupon.getIssuedQuantity();
+        this.startTime = coupon.getStartTime();
+        this.endTime = coupon.getEndTime();
+    }
+
+    public static CouponListResponse from(Coupon coupon) {
+        return new CouponListResponse(coupon);
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/CouponListResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/CouponListResponse.java
@@ -19,8 +19,8 @@ public class CouponListResponse {
     private CouponListResponse(Coupon coupon) {
         this.couponId = coupon.getId();
         this.name = coupon.getName();
-        this.discountAmount = coupon.getDiscountPrice();
-        this.totalQuantity = coupon.getTotalCount();
+        this.discountAmount = coupon.getDiscountAmount();
+        this.totalQuantity = coupon.getTotalQuantity();
         this.issuedQuantity = coupon.getIssuedQuantity();
         this.startTime = coupon.getStartTime();
         this.endTime = coupon.getEndTime();

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/UserCouponResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/UserCouponResponse.java
@@ -18,7 +18,7 @@ public class UserCouponResponse {
     private UserCouponResponse(UserCoupon userCoupon) {
         this.userCouponId = userCoupon.getId();
         this.couponName = userCoupon.getCoupon().getName();
-        this.discountAmount = userCoupon.getCoupon().getDiscountPrice();
+        this.discountAmount = userCoupon.getCoupon().getDiscountAmount();
         this.expiredAt = userCoupon.getExpiredAt();
         this.status = userCoupon.getStatus();
     }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/UserCouponResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/UserCouponResponse.java
@@ -1,0 +1,29 @@
+package com.spartafarmer.agri_commerce.domain.coupon.dto.response;
+
+import com.spartafarmer.agri_commerce.common.enums.CouponStatus;
+import com.spartafarmer.agri_commerce.domain.coupon.entity.UserCoupon;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class UserCouponResponse {
+
+    private final Long userCouponId;
+    private final String couponName;
+    private final Long discountAmount;
+    private final LocalDateTime expiredAt;
+    private final CouponStatus status;
+
+    private UserCouponResponse(UserCoupon userCoupon) {
+        this.userCouponId = userCoupon.getId();
+        this.couponName = userCoupon.getCoupon().getName();
+        this.discountAmount = userCoupon.getCoupon().getDiscountPrice();
+        this.expiredAt = userCoupon.getExpiredAt();
+        this.status = userCoupon.getStatus();
+    }
+
+    public static UserCouponResponse from(UserCoupon userCoupon) {
+        return new UserCouponResponse(userCoupon);
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/entity/Coupon.java
@@ -23,12 +23,12 @@ public class Coupon extends BaseEntity {
     private String name;
 
     // 정액 할인 금액
-    @Column(nullable = false)
-    private Long discountPrice;
+    @Column(name = "discount_price", nullable = false)
+    private Long discountAmount;
 
     // 발급 가능 총 수량
-    @Column(nullable = false)
-    private int totalCount;
+    @Column(name = "total_count", nullable = false)
+    private int totalQuantity;
 
     // 현재 발급된 수량 (동시성 제어 대상)
     @Column(nullable = false)
@@ -42,20 +42,20 @@ public class Coupon extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime endTime;
 
-    private Coupon(String name, Long discountPrice, int totalCount,
+    private Coupon(String name, Long discountAmount, int totalQuantity,
                    LocalDateTime startTime, LocalDateTime endTime) {
         this.name = name;
-        this.discountPrice = discountPrice;
-        this.totalCount = totalCount;
+        this.discountAmount = discountAmount;
+        this.totalQuantity = totalQuantity;
         this.issuedQuantity = 0;
         this.startTime = startTime;
         this.endTime = endTime;
     }
 
     // 쿠폰 생성
-    public static Coupon create(String name, Long discountPrice, int totalCount,
+    public static Coupon create(String name, Long discountAmount, int totalQuantity,
                                 LocalDateTime startTime, LocalDateTime endTime) {
-        return new Coupon(name, discountPrice, totalCount, startTime, endTime);
+        return new Coupon(name, discountAmount, totalQuantity, startTime, endTime);
     }
 
     // 발급 수량 증가 (Redis Lock 획득 후 호출)
@@ -65,7 +65,7 @@ public class Coupon extends BaseEntity {
 
     // 잔여 수량 확인
     public boolean hasRemaining() {
-        return this.issuedQuantity < this.totalCount;
+        return this.issuedQuantity < this.totalQuantity;
     }
 
     // 발급 가능 시간 확인

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/repository/UserCouponRepository.java
@@ -21,4 +21,7 @@ public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
 
     // 단건 조회 (쿠폰 사용 시)
     Optional<UserCoupon> findByIdAndUserId(Long id, Long userId);
+
+    // 사용자 보유 쿠폰 전체 조회 (만료 임박순)
+    List<UserCoupon> findByUserIdOrderByExpiredAtAsc(Long userId);
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/repository/UserCouponRepository.java
@@ -4,6 +4,8 @@ import com.spartafarmer.agri_commerce.common.enums.CouponStatus;
 import com.spartafarmer.agri_commerce.domain.coupon.entity.UserCoupon;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +24,7 @@ public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
     // 단건 조회 (쿠폰 사용 시)
     Optional<UserCoupon> findByIdAndUserId(Long id, Long userId);
 
-    // 사용자 보유 쿠폰 전체 조회 (만료 임박순)
-    List<UserCoupon> findByUserIdOrderByExpiredAtAsc(Long userId);
+    // 사용자 보유 쿠폰 전체 조회 (만료 임박순, Coupon fetch join) -> N+1 해결(Fetch Join)
+    @Query("SELECT uc FROM UserCoupon uc JOIN FETCH uc.coupon WHERE uc.user.id = :userId ORDER BY uc.expiredAt ASC")
+    List<UserCoupon> findByUserIdOrderByExpiredAtAsc(@Param("userId") Long userId);
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponService.java
@@ -10,6 +10,8 @@ import com.spartafarmer.agri_commerce.domain.coupon.entity.Coupon;
 import com.spartafarmer.agri_commerce.domain.coupon.repository.CouponRepository;
 import com.spartafarmer.agri_commerce.domain.coupon.repository.UserCouponRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,10 +55,9 @@ public class CouponService {
 
     // 쿠폰 전체 목록 조회 (관리자)
     @Transactional(readOnly = true)
-    public List<CouponListResponse> getCoupons() {
-        return couponRepository.findAll().stream()
-                .map(CouponListResponse::from)
-                .toList();
+    public Page<CouponListResponse> getCoupons(Pageable pageable) {
+        return couponRepository.findAll(pageable)
+                .map(CouponListResponse::from);
     }
 
     // 내 쿠폰 목록 조회 (만료 임박순)

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponService.java
@@ -4,19 +4,24 @@ import com.spartafarmer.agri_commerce.common.exception.CustomException;
 import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.request.CouponCreateRequest;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponCreateResponse;
+import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponListResponse;
+import com.spartafarmer.agri_commerce.domain.coupon.dto.response.UserCouponResponse;
 import com.spartafarmer.agri_commerce.domain.coupon.entity.Coupon;
 import com.spartafarmer.agri_commerce.domain.coupon.repository.CouponRepository;
+import com.spartafarmer.agri_commerce.domain.coupon.repository.UserCouponRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class CouponService {
 
     private final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
 
     // 쿠폰 생성 (관리자)
     @Transactional
@@ -44,5 +49,21 @@ public class CouponService {
 
         couponRepository.save(coupon);
         return CouponCreateResponse.from(coupon);
+    }
+
+    // 쿠폰 전체 목록 조회 (관리자)
+    @Transactional(readOnly = true)
+    public List<CouponListResponse> getCoupons() {
+        return couponRepository.findAll().stream()
+                .map(CouponListResponse::from)
+                .toList();
+    }
+
+    // 내 쿠폰 목록 조회 (만료 임박순)
+    @Transactional(readOnly = true)
+    public List<UserCouponResponse> getMyCoupons(Long userId) {
+        return userCouponRepository.findByUserIdOrderByExpiredAtAsc(userId).stream()
+                .map(UserCouponResponse::from)
+                .toList();
     }
 }


### PR DESCRIPTION
📌 작업 내용- 어떤 작업인지 한 줄로 설명
관리자 쿠폰 목록 조회 / 내 쿠폰 목록 조회 API 구현 및 Coupon 엔티티 필드명 정책 기준 통일

🔗 관련 이슈- close #이슈번호
close #32 

🧩 변경 사항- 주요 변경 내용- 핵심 로직 / 구현 포인트
- CouponListResponse / UserCouponResponse DTO 생성
- CouponService에 조회 메서드 2개 추가 (관리자 페이징 조회 + 사용자 보유 쿠폰)
- CouponController에 GET /api/coupons, GET /api/coupons/me 엔드포인트 추가
- 관리자 쿠폰 목록 페이징 적용 (findAll → Page)
- UserCoupon 조회 시 Fetch Join으로 N+1 해결
- Coupon 엔티티 필드명 정책 기준 통일 (discountPrice→discountAmount, ->totalCount→totalQuantity)

🧪 테스트
- [x] Postman 1차 테스트 완료

- [ ] 단위 테스트 완료 (해당 시)


🔥 리뷰 요청 (있으면 작성)- 중점적으로 봐줬으면 하는 부분 1개
