### PR TITLE
[fix] main 브랜치 Dockerfile 베이스 이미지 수정 (#85)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN gradle assemble --no-daemon
 # ================================
 # 2단계: 실행 스테이지
 # ================================
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jre-jammy
 WORKDIR /app
 
 # 빌드 스테이지에서 생성된 jar 파일만 복사


### PR DESCRIPTION
📌 작업 내용
- main 브랜치 Dockerfile 베이스 이미지 수정으로 dev → main 충돌 해결

🔗 관련 이슈
- close #85

🧩 변경 사항
- FROM openjdk:17-jdk-slim → FROM eclipse-temurin:17-jre-jammy 변경

🧪 테스트
- [ ] Postman 1차 테스트 완료 (해당 없음)
- [ ] 단위 테스트 완료 (해당 없음)

🔥 리뷰 요청
- 없음