### PR TITLE
feat: Cart API 구현

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/common/exception/ErrorCode.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/common/exception/ErrorCode.java
@@ -30,9 +30,16 @@ public enum ErrorCode {
     // 상품
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
     PRODUCT_NOT_ON_SALE(HttpStatus.BAD_REQUEST, "현재 판매 중인 상품이 아닙니다."),
+
+    PRODUCT_SOLD_OUT(HttpStatus.CONFLICT, "품절된 상품입니다."),
+    PRODUCT_SALE_ENDED(HttpStatus.CONFLICT, "판매 종료된 상품입니다."),
     // 주문
 
     // 장바구니
+    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다."),
+    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니 상품을 찾을 수 없습니다."),
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "수량은 1개 이상이어야 합니다."),
+    OUT_OF_STOCK(HttpStatus.CONFLICT, "재고가 부족합니다."),
 
     // 쿠폰
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "쿠폰을 찾을 수 없습니다."),

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/controller/CartController.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/controller/CartController.java
@@ -1,0 +1,47 @@
+package com.spartafarmer.agri_commerce.domain.cart.controller;
+
+import com.spartafarmer.agri_commerce.common.response.ApiResponse;
+import com.spartafarmer.agri_commerce.common.security.AuthUser;
+import com.spartafarmer.agri_commerce.domain.cart.dto.*;
+import com.spartafarmer.agri_commerce.domain.cart.service.CartService;
+import com.spartafarmer.agri_commerce.domain.user.entity.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/carts")
+public class CartController {
+    private final CartService cartService;
+
+    // 장바구나 담기
+    @PostMapping
+    public ApiResponse<CartAddResponse> addCart(
+            @Valid @RequestBody CartAddRequest request,
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        return ApiResponse.success(201, "장바구니 담기 성공", cartService.addCart(authUser.getId(), request));
+    }
+
+    // 장바구니 조회
+    @GetMapping
+    public ApiResponse<CartResponse> getCart(@AuthenticationPrincipal AuthUser authUser) {
+        return ApiResponse.success(200, "장바구니 조회 성공", cartService.getCart(authUser.getId()));
+    }
+
+    // 수량 변경
+    @PatchMapping("/{cartItemId}")
+    public ApiResponse<CartUpdateResponse> updateQuantity(@PathVariable Long cartItemId, @RequestBody CartUpdateRequest request) {
+        return ApiResponse.success(200, "장바구니 수량 변경 성공", cartService.updateQuantity(cartItemId, request));
+    }
+
+    // 장바구니 삭제 (소프트 딜리트)
+    @PatchMapping("/items/{cartItemId}")
+    public ApiResponse<Void> deleteCartItem(@PathVariable Long cartItemId) {
+        cartService.deleteCartItem(cartItemId);
+        return ApiResponse.success(200, "장바구니 상품 삭제 성공", null);
+    }
+
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/controller/CartController.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/controller/CartController.java
@@ -4,7 +4,6 @@ import com.spartafarmer.agri_commerce.common.response.ApiResponse;
 import com.spartafarmer.agri_commerce.common.security.AuthUser;
 import com.spartafarmer.agri_commerce.domain.cart.dto.*;
 import com.spartafarmer.agri_commerce.domain.cart.service.CartService;
-import com.spartafarmer.agri_commerce.domain.user.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -33,14 +32,16 @@ public class CartController {
 
     // 수량 변경
     @PatchMapping("/{cartItemId}")
-    public ApiResponse<CartUpdateResponse> updateQuantity(@PathVariable Long cartItemId, @RequestBody CartUpdateRequest request) {
-        return ApiResponse.success(200, "장바구니 수량 변경 성공", cartService.updateQuantity(cartItemId, request));
+    public ApiResponse<CartUpdateResponse> updateQuantity(@PathVariable Long cartItemId,
+                                                          @Valid @RequestBody CartUpdateRequest request,
+                                                          @AuthenticationPrincipal AuthUser authUser) {
+        return ApiResponse.success(200, "장바구니 수량 변경 성공", cartService.updateQuantity(cartItemId, request, authUser.getId()));
     }
 
     // 장바구니 삭제 (소프트 딜리트)
     @PatchMapping("/items/{cartItemId}")
-    public ApiResponse<Void> deleteCartItem(@PathVariable Long cartItemId) {
-        cartService.deleteCartItem(cartItemId);
+    public ApiResponse<Void> deleteCartItem(@PathVariable Long cartItemId, @AuthenticationPrincipal AuthUser authUser) {
+        cartService.deleteCartItem(cartItemId, authUser.getId());
         return ApiResponse.success(200, "장바구니 상품 삭제 성공", null);
     }
 

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartAddRequest.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartAddRequest.java
@@ -1,0 +1,16 @@
+package com.spartafarmer.agri_commerce.domain.cart.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+// 장바구니 담기 dto
+
+@Getter
+public class CartAddRequest {
+    @NotNull(message = "상품 ID는 필수입니다")
+    private  Long productId;
+
+    @Min(value = 1, message = "수량은 1개 이상이어야 합니다")
+    private int quantity;
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartAddResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartAddResponse.java
@@ -1,0 +1,24 @@
+package com.spartafarmer.agri_commerce.domain.cart.dto;
+
+import lombok.Getter;
+
+// 장바구니 담기 dto
+
+@Getter
+public class CartAddResponse {
+    private final Long cartItemId;
+    private final Long productId;
+    private final String productName;
+    private final Long price;
+    private final int quantity;
+    private final Long totalPrice;
+
+    public CartAddResponse(Long cartItemId, Long productId, String productName, Long price, int quantity) {
+        this.cartItemId = cartItemId;
+        this.productId = productId;
+        this.productName = productName;
+        this.price = price;
+        this.quantity = quantity;
+        this.totalPrice = price * quantity; // 총 금액 계산
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartItemResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartItemResponse.java
@@ -1,0 +1,27 @@
+package com.spartafarmer.agri_commerce.domain.cart.dto;
+
+import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
+import lombok.Getter;
+
+// 장바구니 조회 dto
+
+@Getter
+public class CartItemResponse {
+    private final Long cartItemId;
+    private final Long productId;
+    private final String productName;
+    private final Long price;
+    private final int quantity;
+    private final Long totalPrice;
+    private final ProductStatus productStatus;
+
+    public CartItemResponse(Long cartItemId, Long productId, String productName, Long price, int quantity, ProductStatus productStatus) {
+        this.cartItemId = cartItemId;
+        this.productId = productId;
+        this.productName = productName;
+        this.price = price;
+        this.quantity = quantity;
+        this.totalPrice = price * quantity;
+        this.productStatus = productStatus;
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartResponse.java
@@ -1,0 +1,22 @@
+package com.spartafarmer.agri_commerce.domain.cart.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+// 장바구니 조회 dto
+
+@Getter
+public class CartResponse {
+    private final List<CartItemResponse> cartItems;
+    private final Long totalPrice;
+    private final boolean isMinOrderAmountMet; // 최소 주문금액을 충족했는가?
+    private final Long minOrderAmount;
+
+    public CartResponse(List<CartItemResponse> cartItems, Long totalPrice, boolean isMinOrderAmountMet) {
+        this.cartItems = cartItems;
+        this.totalPrice = totalPrice;
+        this.isMinOrderAmountMet = isMinOrderAmountMet;
+        this.minOrderAmount = 20000L; // 최소 주문 금액 정책
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartResponse.java
@@ -10,13 +10,16 @@ import java.util.List;
 public class CartResponse {
     private final List<CartItemResponse> cartItems;
     private final Long totalPrice;
-    private final boolean isMinOrderAmountMet; // 최소 주문금액을 충족했는가?
     private final Long minOrderAmount;
+    private final boolean isMinOrderAmountMet;
 
-    public CartResponse(List<CartItemResponse> cartItems, Long totalPrice, boolean isMinOrderAmountMet) {
+    public CartResponse(List<CartItemResponse> cartItems,
+                        Long totalPrice,
+                        Long minOrderAmount,
+                        boolean isMinOrderAmountMet) {
         this.cartItems = cartItems;
         this.totalPrice = totalPrice;
+        this.minOrderAmount = minOrderAmount;
         this.isMinOrderAmountMet = isMinOrderAmountMet;
-        this.minOrderAmount = 20000L; // 최소 주문 금액 정책
     }
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartUpdateRequest.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.spartafarmer.agri_commerce.domain.cart.dto;
+
+
+// 수량 변경 dto
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+
+@Getter
+public class CartUpdateRequest {
+    @Min(value = 1, message = "수량은 1개 이상이어야 합니다")
+    private int quantity;
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartUpdateRequest.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartUpdateRequest.java
@@ -1,10 +1,9 @@
 package com.spartafarmer.agri_commerce.domain.cart.dto;
 
-
-// 수량 변경 dto
-
 import jakarta.validation.constraints.Min;
 import lombok.Getter;
+
+// 수량 변경 dto
 
 @Getter
 public class CartUpdateRequest {

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartUpdateResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartUpdateResponse.java
@@ -1,0 +1,23 @@
+package com.spartafarmer.agri_commerce.domain.cart.dto;
+
+import lombok.Getter;
+
+// 수량 변경 dto
+@Getter
+public class CartUpdateResponse {
+    private final Long cartItemId;
+    private final Long productId;
+    private final String productName;
+    private final Long price;
+    private final int quantity;
+    private final Long totalPrice;
+
+    public CartUpdateResponse(Long cartItemId, Long productId, String productName, Long price, int quantity) {
+        this.cartItemId = cartItemId;
+        this.productId = productId;
+        this.productName = productName;
+        this.price = price;
+        this.quantity = quantity;
+        this.totalPrice = price * quantity;
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/entity/Cart.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/entity/Cart.java
@@ -26,7 +26,7 @@ public class Cart extends BaseEntity {
     private User user;
 
     @Getter(AccessLevel.NONE)
-    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CartItem> cartItems = new ArrayList<>();
 
     private Cart(User user) {

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/entity/Cart.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/entity/Cart.java
@@ -26,7 +26,7 @@ public class Cart extends BaseEntity {
     private User user;
 
     @Getter(AccessLevel.NONE)
-    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL)
     private List<CartItem> cartItems = new ArrayList<>();
 
     private Cart(User user) {

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/repository/CartItemRepository.java
@@ -13,6 +13,7 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
     // @Where로 deleted_at IS NULL 자동 적용됨
     List<CartItem> findByCart(Cart cart);
 
-    // productId → product으로 변경
     Optional<CartItem> findByCartAndProduct(Cart cart, Product product);
+
+    Optional<CartItem> findByIdAndCart_User_Id(Long cartItemId, Long userId);
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/service/CartService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/service/CartService.java
@@ -1,0 +1,149 @@
+package com.spartafarmer.agri_commerce.domain.cart.service;
+
+import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.domain.cart.dto.*;
+import com.spartafarmer.agri_commerce.domain.cart.entity.Cart;
+import com.spartafarmer.agri_commerce.domain.cart.entity.CartItem;
+import com.spartafarmer.agri_commerce.domain.cart.repository.CartItemRepository;
+import com.spartafarmer.agri_commerce.domain.cart.repository.CartRepository;
+import com.spartafarmer.agri_commerce.domain.product.entity.Product;
+import com.spartafarmer.agri_commerce.domain.product.repository.ProductRepository;
+import com.spartafarmer.agri_commerce.domain.user.entity.User;
+import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CartService {
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final ProductRepository productRepository;
+    private final UserRepository userRepository;
+
+    // 장바구니 담기
+    @Transactional
+    public CartAddResponse addCart(Long userId, CartAddRequest request) {
+
+        // 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 상품 조회
+        Product product = productRepository.findById(request.getProductId())
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+        // 상품 상태 검증
+        validateProductStatus(product);
+        // 사용자 장바구니 조회(없으면 생성)
+        Cart cart = cartRepository.findByUser(user)
+                .orElseGet(() -> cartRepository.save(Cart.create(user)));
+        // 이미 담긴 상품인지 확인
+        CartItem cartItem = cartItemRepository.findByCartAndProduct(cart, product)
+                .orElse(null);
+        // 존재하면 수량 증가
+        if (cartItem != null) {
+            cartItem.updateQuantity(cartItem.getQuantity() + request.getQuantity());
+            return new CartAddResponse(
+                    cartItem.getId(),
+                    product.getId(),
+                    product.getName(),
+                    cartItem.getPrice(),
+                    cartItem.getQuantity()
+            );
+        }
+        // 수량 검증
+        if (request.getQuantity() < 1) {
+            throw new CustomException(ErrorCode.INVALID_QUANTITY);
+        }
+
+        // 재고 검증
+        if (request.getQuantity() > product.getStock()) {
+            throw new CustomException(ErrorCode.OUT_OF_STOCK);
+        }
+
+        // 신규 생성
+        CartItem newItem = CartItem.create(cart, product, product.getSalePrice(), request.getQuantity());
+        cartItemRepository.save(newItem);
+        return new CartAddResponse(
+                newItem.getId(),
+                product.getId(),
+                product.getName(),
+                newItem.getPrice(),
+                newItem.getQuantity()
+        );
+    }
+
+    // 장바구니 조회
+    public CartResponse getCart(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Cart cart = cartRepository.findByUser(user)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
+        List< CartItemResponse> items = cart.getCartItems().stream()
+                .map(item -> new CartItemResponse(
+                        item.getId(),
+                        item.getProduct().getId(),
+                        item.getProduct().getName(),
+                        item.getPrice(),
+                        item.getQuantity(),
+                        item.getProduct().getStatus()
+                )).toList();
+        long totalPrice = items.stream().mapToLong(i -> i.getPrice() * i.getQuantity()).sum();
+        boolean isMinOrderAmountMet = totalPrice >= 20000;
+        return new CartResponse(items, totalPrice, isMinOrderAmountMet);
+    }
+
+    // 수량 변경
+    @Transactional
+    public CartUpdateResponse updateQuantity(Long cartItemId, CartUpdateRequest request) {
+        CartItem cartItem = cartItemRepository.findById(cartItemId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_ITEM_NOT_FOUND));
+        // 수량 1이상 검증
+        if (request.getQuantity() < 1) {
+            throw new CustomException(ErrorCode.INVALID_QUANTITY);
+        }
+
+        // 재고 초과 검증
+        if (request.getQuantity() > cartItem.getProduct().getStock()) {
+            throw new CustomException(ErrorCode.OUT_OF_STOCK);
+        }
+
+        cartItem.updateQuantity(request.getQuantity());
+        return new CartUpdateResponse(
+                cartItem.getId(),
+                cartItem.getProduct().getId(),
+                cartItem.getProduct().getName(),
+                cartItem.getPrice(),
+                cartItem.getQuantity()
+    );
+    }
+
+    // 장바구니 삭제(소프트 딜리트)
+    @Transactional
+    public void deleteCartItem(Long cartItemId) {
+
+        // 삭제 대상 조회
+        CartItem cartItem = cartItemRepository.findById(cartItemId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_ITEM_NOT_FOUND));
+
+        // Soft Delete 실행 (JPA가 update로 변환)
+        cartItemRepository.delete(cartItem);
+    }
+
+    // 상품 상태 검증
+    private void validateProductStatus(Product product) {
+        if (product.getStatus() == ProductStatus.SOLD_OUT) {
+            throw new CustomException(ErrorCode.PRODUCT_SOLD_OUT);
+        }
+        if (product.getStatus() == ProductStatus.SALE_ENDED) {
+            throw new CustomException(ErrorCode.PRODUCT_SALE_ENDED);
+        }
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/service/CartService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/service/CartService.java
@@ -26,29 +26,49 @@ public class CartService {
     private final CartItemRepository cartItemRepository;
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
+    private static final long MIN_ORDER_AMOUNT = 20000L;
 
     // 장바구니 담기
     @Transactional
     public CartAddResponse addCart(Long userId, CartAddRequest request) {
 
-        // 유저 조회
+        // 1. 수량 검증
+        if (request.getQuantity() < 1) {
+            throw new CustomException(ErrorCode.INVALID_QUANTITY);
+        }
+
+        // 2. 유저 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        // 상품 조회
+        // 3. 상품 조회
         Product product = productRepository.findById(request.getProductId())
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
-        // 상품 상태 검증
+
         validateProductStatus(product);
-        // 사용자 장바구니 조회(없으면 생성)
+
+        // 4. 재고 검증
+        if (request.getQuantity() > product.getStock()) {
+            throw new CustomException(ErrorCode.OUT_OF_STOCK);
+        }
+
+        // 5. 장바구니 조회
         Cart cart = cartRepository.findByUser(user)
                 .orElseGet(() -> cartRepository.save(Cart.create(user)));
-        // 이미 담긴 상품인지 확인
+
+        // 6. 기존 상품 여부 확인
         CartItem cartItem = cartItemRepository.findByCartAndProduct(cart, product)
                 .orElse(null);
-        // 존재하면 수량 증가
+
         if (cartItem != null) {
-            cartItem.updateQuantity(cartItem.getQuantity() + request.getQuantity());
+            int newQuantity = cartItem.getQuantity() + request.getQuantity();
+
+            if (newQuantity > product.getStock()) {
+                throw new CustomException(ErrorCode.OUT_OF_STOCK);
+            }
+
+            cartItem.updateQuantity(newQuantity);
+
             return new CartAddResponse(
                     cartItem.getId(),
                     product.getId(),
@@ -57,19 +77,11 @@ public class CartService {
                     cartItem.getQuantity()
             );
         }
-        // 수량 검증
-        if (request.getQuantity() < 1) {
-            throw new CustomException(ErrorCode.INVALID_QUANTITY);
-        }
 
-        // 재고 검증
-        if (request.getQuantity() > product.getStock()) {
-            throw new CustomException(ErrorCode.OUT_OF_STOCK);
-        }
-
-        // 신규 생성
+        // 7. 신규 생성
         CartItem newItem = CartItem.create(cart, product, product.getSalePrice(), request.getQuantity());
         cartItemRepository.save(newItem);
+
         return new CartAddResponse(
                 newItem.getId(),
                 product.getId(),
@@ -96,16 +108,22 @@ public class CartService {
                         item.getProduct().getStatus()
                 )).toList();
         long totalPrice = items.stream().mapToLong(i -> i.getPrice() * i.getQuantity()).sum();
-        boolean isMinOrderAmountMet = totalPrice >= 20000;
-        return new CartResponse(items, totalPrice, isMinOrderAmountMet);
+        boolean isMinOrderAmountMet = totalPrice >= MIN_ORDER_AMOUNT;
+        return new CartResponse(items, totalPrice, MIN_ORDER_AMOUNT, isMinOrderAmountMet);
     }
 
     // 수량 변경
     @Transactional
-    public CartUpdateResponse updateQuantity(Long cartItemId, CartUpdateRequest request) {
+    public CartUpdateResponse updateQuantity(Long cartItemId, CartUpdateRequest request, Long userId) {
         CartItem cartItem = cartItemRepository.findById(cartItemId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CART_ITEM_NOT_FOUND));
-        // 수량 1이상 검증
+
+        // 내 장바구니인지 검증
+        if (!cartItem.getCart().getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 수량 검증
         if (request.getQuantity() < 1) {
             throw new CustomException(ErrorCode.INVALID_QUANTITY);
         }
@@ -127,11 +145,15 @@ public class CartService {
 
     // 장바구니 삭제(소프트 딜리트)
     @Transactional
-    public void deleteCartItem(Long cartItemId) {
+    public void deleteCartItem(Long cartItemId, Long userId) {
 
         // 삭제 대상 조회
         CartItem cartItem = cartItemRepository.findById(cartItemId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CART_ITEM_NOT_FOUND));
+
+        if (!cartItem.getCart().getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
 
         // Soft Delete 실행 (JPA가 update로 변환)
         cartItemRepository.delete(cartItem);

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/service/CartService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/service/CartService.java
@@ -32,31 +32,26 @@ public class CartService {
     @Transactional
     public CartAddResponse addCart(Long userId, CartAddRequest request) {
 
-        // 1. 수량 검증
-        if (request.getQuantity() < 1) {
-            throw new CustomException(ErrorCode.INVALID_QUANTITY);
-        }
-
-        // 2. 유저 조회
+        // 유저 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        // 3. 상품 조회
+        // 상품 조회
         Product product = productRepository.findById(request.getProductId())
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
         validateProductStatus(product);
 
-        // 4. 재고 검증
+        // 재고 검증
         if (request.getQuantity() > product.getStock()) {
             throw new CustomException(ErrorCode.OUT_OF_STOCK);
         }
 
-        // 5. 장바구니 조회
+        // 장바구니 조회
         Cart cart = cartRepository.findByUser(user)
                 .orElseGet(() -> cartRepository.save(Cart.create(user)));
 
-        // 6. 기존 상품 여부 확인
+        // 기존 상품 여부 확인
         CartItem cartItem = cartItemRepository.findByCartAndProduct(cart, product)
                 .orElse(null);
 
@@ -78,7 +73,7 @@ public class CartService {
             );
         }
 
-        // 7. 신규 생성
+        // 신규 생성
         CartItem newItem = CartItem.create(cart, product, product.getSalePrice(), request.getQuantity());
         cartItemRepository.save(newItem);
 
@@ -115,18 +110,9 @@ public class CartService {
     // 수량 변경
     @Transactional
     public CartUpdateResponse updateQuantity(Long cartItemId, CartUpdateRequest request, Long userId) {
-        CartItem cartItem = cartItemRepository.findById(cartItemId)
+        CartItem cartItem = cartItemRepository.findByIdAndCart_User_Id(cartItemId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CART_ITEM_NOT_FOUND));
 
-        // 내 장바구니인지 검증
-        if (!cartItem.getCart().getUser().getId().equals(userId)) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
-
-        // 수량 검증
-        if (request.getQuantity() < 1) {
-            throw new CustomException(ErrorCode.INVALID_QUANTITY);
-        }
 
         // 재고 초과 검증
         if (request.getQuantity() > cartItem.getProduct().getStock()) {
@@ -148,12 +134,8 @@ public class CartService {
     public void deleteCartItem(Long cartItemId, Long userId) {
 
         // 삭제 대상 조회
-        CartItem cartItem = cartItemRepository.findById(cartItemId)
+        CartItem cartItem = cartItemRepository.findByIdAndCart_User_Id(cartItemId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CART_ITEM_NOT_FOUND));
-
-        if (!cartItem.getCart().getUser().getId().equals(userId)) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
 
         // Soft Delete 실행 (JPA가 update로 변환)
         cartItemRepository.delete(cartItem);


### PR DESCRIPTION
📌 작업 내용
- 장바구니 담기
- 장바구니 조회
- 장바구니 수량 변경
- 장바구니 상품 삭제(소프트 딜리트)


🔗 관련 이슈- close #34 


🧩 변경 사항- 주요 변경 내용
1. 장바구니 도메인
2. 장바구니 담기 
    - 기존 상품 존재 시 수량 증가
    - 없으면 신규생성
    - 상품 상태 검증(품절/판매종료) -> 담기 불가능
4. 유효성 검증
    - 수량 1 이상만 허용
    - 재고 초과 시 예외처리
    - 수량 변경시에도 동일 검증 적용
5. 삭제 기능(소프트 딜리트)
    - @SQLDelete, @Where 적용
    - 삭제 시 deleted_at 업뎃
7. 인증 기반 사용자 처리
    - AuthUser → userId → User 조회 방식
9. 에러코드 추가


🧪 테스트
- [x] Postman 1차 테스트 완료

    - 장바구니 담기
    - 동일 상품 추가 시 수량 증가 확인
    - 수량 변경 정상 동작 확인
    - 재고 초과 요청 → 예외 발생 확인
    - 수량 0 / 음수 → 예외 발생 확인
    - 삭제(소프트 딜리트) 정상 동작 확인
    - 인증 없이 요청 시 403 확인


🔥 리뷰 요청
공통에러코드에 상품관련 에러코드도 추가했으니 확인 부탁드립니다.
