### PR TITLE
feat: order api 구현

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/common/exception/ErrorCode.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/common/exception/ErrorCode.java
@@ -34,6 +34,10 @@ public enum ErrorCode {
     PRODUCT_SOLD_OUT(HttpStatus.CONFLICT, "품절된 상품입니다."),
     PRODUCT_SALE_ENDED(HttpStatus.CONFLICT, "판매 종료된 상품입니다."),
     // 주문
+    CART_EMPTY(HttpStatus.BAD_REQUEST, "장바구니가 비어있습니다."),
+    MIN_ORDER_AMOUNT_NOT_MET(HttpStatus.BAD_REQUEST, "최소 주문 금액은 20,000원 이상입니다."),
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
+    ORDER_LOCK_FAILED(HttpStatus.TOO_MANY_REQUESTS, "현재 요청이 많아 처리할 수 없습니다. 잠시 후 다시 시도해주세요."),
 
     // 장바구니
     CART_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니를 찾을 수 없습니다."),

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/entity/UserCoupon.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/entity/UserCoupon.java
@@ -2,6 +2,8 @@ package com.spartafarmer.agri_commerce.domain.coupon.entity;
 
 import com.spartafarmer.agri_commerce.common.entity.BaseEntity;
 import com.spartafarmer.agri_commerce.common.enums.CouponStatus;
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
 import com.spartafarmer.agri_commerce.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -66,5 +68,21 @@ public class UserCoupon extends BaseEntity {
     // 쿠폰 만료 처리 (스케줄러 일괄 처리용)
     public void expire() {
         this.status = CouponStatus.EXPIRED;
+    }
+
+    // 쿠폰 사용 가능 여부 검증
+    public void validateUsable(LocalDateTime now) {
+
+        if (this.expiredAt.isBefore(now)) {
+            throw new CustomException(ErrorCode.USER_COUPON_EXPIRED);
+        }
+
+        if (this.status == CouponStatus.USED) {
+            throw new CustomException(ErrorCode.USER_COUPON_ALREADY_USED);
+        }
+
+        if (this.status == CouponStatus.EXPIRED) {
+            throw new CustomException(ErrorCode.USER_COUPON_EXPIRED);
+        }
     }
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/controller/OrderController.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/controller/OrderController.java
@@ -1,0 +1,52 @@
+package com.spartafarmer.agri_commerce.domain.order.controller;
+
+import com.spartafarmer.agri_commerce.common.response.ApiResponse;
+import com.spartafarmer.agri_commerce.common.security.AuthUser;
+import com.spartafarmer.agri_commerce.domain.order.dto.OrderCreateRequest;
+import com.spartafarmer.agri_commerce.domain.order.dto.OrderCreateResponse;
+import com.spartafarmer.agri_commerce.domain.order.dto.OrderListResponse;
+import com.spartafarmer.agri_commerce.domain.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    // 주문 생성
+    @PostMapping
+    public ApiResponse<OrderCreateResponse> createOrder(
+            @AuthenticationPrincipal AuthUser authUser,
+            @RequestBody OrderCreateRequest request
+    ) {
+        OrderCreateResponse response =
+                orderService.createOrder(authUser.getId(), request.getUserCouponId());
+
+        return ApiResponse.success(
+                201,
+                "주문 생성 성공",
+                response
+        );
+    }
+
+    // 주문 목록 조회
+    @GetMapping
+    public ApiResponse<List<OrderListResponse>> getOrders(
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        List<OrderListResponse> response =
+                orderService.getOrders(authUser.getId());
+
+        return ApiResponse.success(
+                200,
+                "주문 목록 조회 성공",
+                response
+        );
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderCreateRequest.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderCreateRequest.java
@@ -1,0 +1,11 @@
+package com.spartafarmer.agri_commerce.domain.order.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OrderCreateRequest {
+    // 쿠폰 미사용시 null
+    private Long userCouponId;
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderCreateResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderCreateResponse.java
@@ -1,0 +1,37 @@
+package com.spartafarmer.agri_commerce.domain.order.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class OrderCreateResponse {
+
+    private final Long orderId;
+    private final List<OrderItemResponse> orderItems;
+
+    private final Long originalPrice;
+    private final Long discountAmount;
+    private final Long finalPrice;
+
+    private final String status;
+    private final LocalDateTime orderedAt;
+
+    public OrderCreateResponse(Long orderId,
+                               List<OrderItemResponse> orderItems,
+                               Long originalPrice,
+                               Long discountAmount,
+                               Long finalPrice,
+                               String status,
+                               LocalDateTime orderedAt) {
+
+        this.orderId = orderId;
+        this.orderItems = orderItems;
+        this.originalPrice = originalPrice;
+        this.discountAmount = discountAmount;
+        this.finalPrice = finalPrice;
+        this.status = status;
+        this.orderedAt = orderedAt;
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderItemResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderItemResponse.java
@@ -1,0 +1,19 @@
+package com.spartafarmer.agri_commerce.domain.order.dto;
+
+import lombok.Getter;
+
+@Getter
+public class OrderItemResponse {
+
+    private final String productName;
+    private final int quantity;
+    private final Long price;
+    private final Long totalPrice;
+
+    public OrderItemResponse(String productName, int quantity, Long price, Long totalPrice) {
+        this.productName = productName;
+        this.quantity = quantity;
+        this.price = price;
+        this.totalPrice = totalPrice;
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderListResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderListResponse.java
@@ -1,0 +1,24 @@
+package com.spartafarmer.agri_commerce.domain.order.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class OrderListResponse {
+
+    private final Long orderId;
+    private final List<OrderItemResponse> orderItems;
+    private final Long finalPrice;
+    private final String status;
+    private final LocalDateTime orderedAt;
+
+    public OrderListResponse(Long orderId, List<OrderItemResponse> orderItems, Long finalPrice, String status, LocalDateTime orderedAt) {
+        this.orderId = orderId;
+        this.orderItems = orderItems;
+        this.finalPrice = finalPrice;
+        this.status = status;
+        this.orderedAt = orderedAt;
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/entity/Order.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/entity/Order.java
@@ -21,7 +21,7 @@ public class Order extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     // 쿠폰 미적용시 null 허용
@@ -51,8 +51,7 @@ public class Order extends BaseEntity {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<OrderItem> orderItems = new ArrayList<>();
 
-    // 주문 생성 (성공한 경우만 생성됨)
-    // 실패 - DB 저장 안됨, 성공시 COMPLETED만 존재
+    // 주문 생성
     public static Order create(User user, UserCoupon coupon,
                                Long totalPrice, Long discountPrice, Long finalPrice) {
 
@@ -65,6 +64,22 @@ public class Order extends BaseEntity {
         order.status = OrderStatus.COMPLETED;
         return order;
     }
+
+    // 주문 실패
+    public static Order fail(User user,
+                             UserCoupon coupon,
+                             Long totalPrice) {
+
+        Order order = new Order();
+        order.user = user;
+        order.coupon = coupon;
+        order.totalPrice = totalPrice;
+        order.discountPrice = 0L;
+        order.finalPrice = totalPrice;
+        order.status = OrderStatus.FAILED;
+        return order;
+    }
+
 
     // 주문에 상품을 포함시키기 위한 메서드 (양방향 관계 동기화)
     public void addOrderItem(OrderItem orderItem) {

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/entity/OrderStatus.java
@@ -2,4 +2,5 @@ package com.spartafarmer.agri_commerce.domain.order.entity;
 
 public enum OrderStatus {
     COMPLETED, // 결제 완료(구매하기 성공시 즉시 확정)
+    FAILED
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/service/OrderService.java
@@ -1,0 +1,169 @@
+package com.spartafarmer.agri_commerce.domain.order.service;
+
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.domain.cart.entity.Cart;
+import com.spartafarmer.agri_commerce.domain.cart.entity.CartItem;
+import com.spartafarmer.agri_commerce.domain.cart.repository.CartRepository;
+import com.spartafarmer.agri_commerce.domain.coupon.entity.UserCoupon;
+import com.spartafarmer.agri_commerce.domain.coupon.repository.UserCouponRepository;
+import com.spartafarmer.agri_commerce.domain.order.dto.OrderCreateResponse;
+import com.spartafarmer.agri_commerce.domain.order.dto.OrderItemResponse;
+import com.spartafarmer.agri_commerce.domain.order.dto.OrderListResponse;
+import com.spartafarmer.agri_commerce.domain.order.entity.Order;
+import com.spartafarmer.agri_commerce.domain.order.entity.OrderItem;
+import com.spartafarmer.agri_commerce.domain.order.repository.OrderRepository;
+import com.spartafarmer.agri_commerce.domain.product.entity.Product;
+import com.spartafarmer.agri_commerce.domain.product.repository.ProductRepository;
+import com.spartafarmer.agri_commerce.domain.user.entity.User;
+import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OrderService {
+
+    private final UserRepository userRepository;
+    private final CartRepository cartRepository;
+    private final ProductRepository productRepository;
+    private final OrderRepository orderRepository;
+    private final UserCouponRepository userCouponRepository;
+
+    // 장바구니 전체 주문 생성
+    public OrderCreateResponse createOrder(Long userId, Long userCouponId) {
+
+        // 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 장바구니 조회
+        Cart cart = cartRepository.findByUser(user)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
+
+        List<CartItem> cartItems = cart.getCartItems();
+
+        if (cartItems.isEmpty()) {
+            throw new CustomException(ErrorCode.CART_EMPTY);
+        }
+
+        long totalPrice = 0L;
+        boolean hasCoupon = (userCouponId != null);
+
+        // 상품 검증 + 금액 계산
+        for (CartItem item : cartItems) {
+
+            Product product = item.getProduct();
+
+            product.validateOrderable(item.getQuantity());
+
+            // 특가 + 쿠폰 제한
+            if (hasCoupon && product.getSpecialPrice() != null) {
+                throw new CustomException(ErrorCode.COUPON_NOT_APPLICABLE);
+            }
+
+            totalPrice += product.getSalePrice() * item.getQuantity();
+        }
+
+        // 쿠폰 처리
+        UserCoupon userCoupon = null;
+        long discountPrice = 0L;
+
+        if (hasCoupon) {
+
+            userCoupon = userCouponRepository.findById(userCouponId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.COUPON_NOT_FOUND));
+
+            userCoupon.validateUsable(LocalDateTime.now());
+
+            discountPrice = userCoupon.getCoupon().getDiscountAmount();
+        }
+
+        long finalPrice = totalPrice - discountPrice;
+
+        // 최소 주문 금액
+        if (finalPrice < 20000) {
+            throw new CustomException(ErrorCode.MIN_ORDER_AMOUNT_NOT_MET);
+        }
+
+        //  주문 생성
+        Order order = Order.create(user, userCoupon, totalPrice, discountPrice, finalPrice);
+
+        // 주문 아이템 + 재고 차감
+        for (CartItem item : cartItems) {
+
+            Product product = item.getProduct();
+
+            product.decreaseStock(item.getQuantity());
+
+            OrderItem orderItem = OrderItem.create(
+                    order,
+                    product,
+                    product.getSalePrice(),
+                    item.getQuantity()
+            );
+
+            order.addOrderItem(orderItem);
+        }
+
+        orderRepository.save(order);
+
+        // 쿠폰 사용 처리
+        if (userCoupon != null) {
+            userCoupon.use();
+        }
+
+        // 장바구니 초기화
+        cart.getCartItems().clear();
+
+        // 응답
+        return new OrderCreateResponse(
+                order.getId(),
+                order.getOrderItems().stream()
+                        .map(i -> new OrderItemResponse(
+                                i.getProduct().getName(),
+                                i.getQuantity(),
+                                i.getPrice(),
+                                i.getPrice() * i.getQuantity()
+                        ))
+                        .toList(),
+                order.getTotalPrice(),
+                order.getDiscountPrice(),
+                order.getFinalPrice(),
+                order.getStatus().name(),
+                order.getCreatedAt()
+        );
+    }
+
+    // 주문 목록 조회
+    @Transactional(readOnly = true)
+    public List<OrderListResponse> getOrders(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<Order> orders = orderRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+
+        return orders.stream()
+                .map(order -> new OrderListResponse(
+                        order.getId(),
+                        order.getOrderItems().stream()
+                                .map(i -> new OrderItemResponse(
+                                        i.getProduct().getName(),
+                                        i.getQuantity(),
+                                        i.getPrice(),
+                                        i.getPrice() * i.getQuantity()
+                                ))
+                                .toList(),
+                        order.getFinalPrice(),
+                        order.getStatus().name(),
+                        order.getCreatedAt()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/product/entity/Product.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/product/entity/Product.java
@@ -2,6 +2,8 @@ package com.spartafarmer.agri_commerce.domain.product.entity;
 
 import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
 import com.spartafarmer.agri_commerce.common.enums.ProductType;
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -61,5 +63,25 @@ public class Product {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    
+    // 재고 차감
+    public void decreaseStock(int quantity) {
+        if (this.stock < quantity) {
+            throw new CustomException(ErrorCode.OUT_OF_STOCK);
+        }
+        this.stock -= quantity;
+    }
+
+    public void validateOrderable(int quantity) {
+        if (this.status == ProductStatus.SOLD_OUT) {
+            throw new CustomException(ErrorCode.PRODUCT_SOLD_OUT);
+        }
+
+        if (this.status == ProductStatus.SALE_ENDED) {
+            throw new CustomException(ErrorCode.PRODUCT_SALE_ENDED);
+        }
+
+        if (this.stock < quantity) {
+            throw new CustomException(ErrorCode.OUT_OF_STOCK);
+        }
+    }
 }


### PR DESCRIPTION
📌 작업 내용
- 주문 생성 및 주문 목록 조회 API 구현

🔗 관련 이슈- close #73 


🧩 변경 사항
- 주문 생성 API (POST /api/orders) 구현
- 주문 목록 조회 API (GET /api/orders) 구현
- 장바구니 기반 주문 생성 흐름 구현
    -유저 → 장바구니 → 상품 검증 → 주문 생성 → 재고 차감 → 쿠폰 사용 → 장바구니 초기화
- 상품 주문 가능 여부 검증
    - 판매 상태, 재고, 판매 종료 여부 (validateOrderable)
- 최소 주문 금액 검증
    - 20,000원 미만 주문 차단
- 쿠폰 적용 로직
    - 쿠폰 유효성 검사 (validateUsable)
    - 특가 상품 포함 시 쿠폰 사용 제한


🧪 테스트
- [ ] Postman 1차 테스트 완료

- [ ] 단위 테스트 완료 (해당 시)


🔥 리뷰 요청
- UserCoupon에 validateUsable 메서드 추가
- Produnt에 decreaseStock,  validateOrderable 메서드 추가
- ErrorCode 추가(주문+ 상품)
