### PR TITLE
feat: 선착순 쿠폰 발급 API(#72)

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/controller/CouponController.java
@@ -4,6 +4,7 @@ import com.spartafarmer.agri_commerce.common.response.ApiResponse;
 import com.spartafarmer.agri_commerce.common.security.AuthUser;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.request.CouponCreateRequest;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponCreateResponse;
+import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponIssueResponse;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponListResponse;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.response.UserCouponResponse;
 import com.spartafarmer.agri_commerce.domain.coupon.service.CouponService;
@@ -50,4 +51,13 @@ public class CouponController {
             @AuthenticationPrincipal AuthUser authUser) {
         return ResponseEntity.ok(ApiResponse.success(couponService.getMyCoupons(authUser.getId())));
     }
+
+    // 선착순 쿠폰 발급
+    @PostMapping("/{couponId}/issue")
+    public ResponseEntity<ApiResponse<CouponIssueResponse>> issueCoupon(
+            @PathVariable Long couponId,
+            @AuthenticationPrincipal AuthUser authUser) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+               .body(ApiResponse.success(201, "쿠폰이 발급되었습니다.", couponService.issueCoupon(couponId, authUser.getId())));
+        }
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/CouponIssueResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/response/CouponIssueResponse.java
@@ -1,0 +1,25 @@
+package com.spartafarmer.agri_commerce.domain.coupon.dto.response;
+
+import com.spartafarmer.agri_commerce.common.enums.CouponStatus;
+import com.spartafarmer.agri_commerce.domain.coupon.entity.UserCoupon;
+
+import java.time.LocalDateTime;
+
+public record CouponIssueResponse (
+
+    Long userCouponId,
+    String couponName,
+    Long discountAmount,
+    CouponStatus status,
+    LocalDateTime expiredAt
+){
+        public static CouponIssueResponse from (UserCoupon userCoupon){
+        return new CouponIssueResponse(
+                userCoupon.getId(),
+                userCoupon.getCoupon().getName(),
+                userCoupon.getCoupon().getDiscountAmount(),
+                userCoupon.getStatus(),
+                userCoupon.getExpiredAt()
+        );
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/entity/UserCoupon.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/entity/UserCoupon.java
@@ -55,7 +55,7 @@ public class UserCoupon extends BaseEntity {
     // 쿠폰 발급
     public static UserCoupon issue(User user, Coupon coupon, LocalDateTime issuedAt) {
         // 발급일 + 5일 23:59:59
-        LocalDateTime expiredAt = issuedAt.toLocalDate().plusDays(5)
+        LocalDateTime expiredAt = issuedAt.toLocalDate().plusDays(4)
                 .atTime(23, 59, 59);
         return new UserCoupon(user, coupon, expiredAt);
     }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponService.java
@@ -4,11 +4,15 @@ import com.spartafarmer.agri_commerce.common.exception.CustomException;
 import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.request.CouponCreateRequest;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponCreateResponse;
+import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponIssueResponse;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponListResponse;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.response.UserCouponResponse;
 import com.spartafarmer.agri_commerce.domain.coupon.entity.Coupon;
+import com.spartafarmer.agri_commerce.domain.coupon.entity.UserCoupon;
 import com.spartafarmer.agri_commerce.domain.coupon.repository.CouponRepository;
 import com.spartafarmer.agri_commerce.domain.coupon.repository.UserCouponRepository;
+import com.spartafarmer.agri_commerce.domain.user.entity.User;
+import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,6 +28,7 @@ public class CouponService {
 
     private final CouponRepository couponRepository;
     private final UserCouponRepository userCouponRepository;
+    private final UserRepository userRepository;
 
     // 쿠폰 생성 (관리자)
     @Transactional
@@ -67,4 +72,40 @@ public class CouponService {
                 .map(UserCouponResponse::from)
                 .toList();
     }
+
+    @Transactional
+    public CouponIssueResponse issueCoupon(Long couponId, Long userId) {
+
+        // 쿠폰 조회
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COUPON_NOT_FOUND));
+
+        // 발급 기간 검증
+        if (!coupon.isAvailableNow(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.COUPON_NOT_AVAILABLE_TIME);
+        }
+
+        // 중복 발급 검증
+        if (userCouponRepository.existsByUserIdAndCouponId(userId, couponId)) {
+            throw new CustomException(ErrorCode.COUPON_ALREADY_ISSUED);
+        }
+
+        // 수량 검증
+        if (!coupon.hasRemaining()) {
+            throw new CustomException(ErrorCode.COUPON_SOLD_OUT);
+        }
+
+        // 발급 수량 증가
+        coupon.increaseIssuedQuantity();
+
+        // UserCoupon 생성, 저장
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        UserCoupon userCoupon = UserCoupon.issue(user, coupon, LocalDateTime.now());
+        userCouponRepository.save(userCoupon);
+
+        return CouponIssueResponse.from(userCoupon);
+    }
+
 }


### PR DESCRIPTION
📌 작업 내용
- 선착순 쿠폰 발급 API 구현

🔗 관련 이슈
- close #72

🧩 변경 사항
- CouponIssueResponse.java 생성 (Record DTO)
- CouponService.issueCoupon() 메서드 추가
- CouponController에 POST /api/coupons/{couponId}/issue 엔드포인트 추가

핵심 로직:
1. 쿠폰 조회 → 발급 기간 검증 → 중복 발급 검증 → 수량 검증
2. issuedQuantity +1, UserCoupon 생성
3. expiredAt = 발급일 + 5일 23:59 (UserCoupon.issue()에서 계산) -> 발급일 포함 5일

🧪 테스트
- [x] Postman 1차 테스트 완료
- [ ] 단위 테스트 완료 (해당 시)


🔥 리뷰 요청 (있으면 작성)- 중점적으로 봐줬으면 하는 부분 1개
