### PR TITLE
Refactor: 장바구니와 주문 dto 형식 record로 통일

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/controller/CartController.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/controller/CartController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class CartController {
     private final CartService cartService;
 
-    // 장바구나 담기
+    // 장바구니 담기
     @PostMapping
     public ApiResponse<CartAddResponse> addCart(
             @Valid @RequestBody CartAddRequest request,
@@ -38,11 +38,10 @@ public class CartController {
         return ApiResponse.success(200, "장바구니 수량 변경 성공", cartService.updateQuantity(cartItemId, request, authUser.getId()));
     }
 
-    // 장바구니 삭제 (소프트 딜리트)
-    @PatchMapping("/items/{cartItemId}")
+    // 장바구니 삭제
+    @DeleteMapping("/items/{cartItemId}")
     public ApiResponse<Void> deleteCartItem(@PathVariable Long cartItemId, @AuthenticationPrincipal AuthUser authUser) {
         cartService.deleteCartItem(cartItemId, authUser.getId());
         return ApiResponse.success(200, "장바구니 상품 삭제 성공", null);
     }
-
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartAddRequest.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartAddRequest.java
@@ -2,15 +2,11 @@ package com.spartafarmer.agri_commerce.domain.cart.dto;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
 
-// 장바구니 담기 dto
+public record CartAddRequest(
+        @NotNull(message = "상품 ID는 필수입니다")
+        Long productId,
 
-@Getter
-public class CartAddRequest {
-    @NotNull(message = "상품 ID는 필수입니다")
-    private  Long productId;
-
-    @Min(value = 1, message = "수량은 1개 이상이어야 합니다")
-    private int quantity;
-}
+        @Min(value = 1, message = "수량은 1개 이상이어야 합니다")
+        int quantity
+) { }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartAddResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartAddResponse.java
@@ -1,24 +1,14 @@
 package com.spartafarmer.agri_commerce.domain.cart.dto;
 
-import lombok.Getter;
-
-// 장바구니 담기 dto
-
-@Getter
-public class CartAddResponse {
-    private final Long cartItemId;
-    private final Long productId;
-    private final String productName;
-    private final Long price;
-    private final int quantity;
-    private final Long totalPrice;
-
+public record CartAddResponse(
+        Long cartItemId,
+        Long productId,
+        String productName,
+        Long price,
+        int quantity,
+        Long totalPrice
+) {
     public CartAddResponse(Long cartItemId, Long productId, String productName, Long price, int quantity) {
-        this.cartItemId = cartItemId;
-        this.productId = productId;
-        this.productName = productName;
-        this.price = price;
-        this.quantity = quantity;
-        this.totalPrice = price * quantity; // 총 금액 계산
+        this(cartItemId, productId, productName, price, quantity, price * quantity);
     }
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartItemResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartItemResponse.java
@@ -1,27 +1,17 @@
 package com.spartafarmer.agri_commerce.domain.cart.dto;
 
 import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
-import lombok.Getter;
 
-// 장바구니 조회 dto
-
-@Getter
-public class CartItemResponse {
-    private final Long cartItemId;
-    private final Long productId;
-    private final String productName;
-    private final Long price;
-    private final int quantity;
-    private final Long totalPrice;
-    private final ProductStatus productStatus;
-
+public record CartItemResponse(
+        Long cartItemId,
+        Long productId,
+        String productName,
+        Long price,
+        int quantity,
+        Long totalPrice,
+        ProductStatus productStatus
+) {
     public CartItemResponse(Long cartItemId, Long productId, String productName, Long price, int quantity, ProductStatus productStatus) {
-        this.cartItemId = cartItemId;
-        this.productId = productId;
-        this.productName = productName;
-        this.price = price;
-        this.quantity = quantity;
-        this.totalPrice = price * quantity;
-        this.productStatus = productStatus;
+        this(cartItemId, productId, productName, price, quantity, price * quantity, productStatus);
     }
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartResponse.java
@@ -1,25 +1,11 @@
 package com.spartafarmer.agri_commerce.domain.cart.dto;
 
-import lombok.Getter;
-
 import java.util.List;
 
-// 장바구니 조회 dto
-
-@Getter
-public class CartResponse {
-    private final List<CartItemResponse> cartItems;
-    private final Long totalPrice;
-    private final Long minOrderAmount;
-    private final boolean isMinOrderAmountMet;
-
-    public CartResponse(List<CartItemResponse> cartItems,
-                        Long totalPrice,
-                        Long minOrderAmount,
-                        boolean isMinOrderAmountMet) {
-        this.cartItems = cartItems;
-        this.totalPrice = totalPrice;
-        this.minOrderAmount = minOrderAmount;
-        this.isMinOrderAmountMet = isMinOrderAmountMet;
-    }
+public record CartResponse(
+        List<CartItemResponse> cartItems,
+        Long totalPrice,
+        Long minOrderAmount,
+        boolean isMinOrderAmountMet
+) {
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartUpdateRequest.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartUpdateRequest.java
@@ -1,12 +1,9 @@
 package com.spartafarmer.agri_commerce.domain.cart.dto;
 
 import jakarta.validation.constraints.Min;
-import lombok.Getter;
 
-// 수량 변경 dto
-
-@Getter
-public class CartUpdateRequest {
-    @Min(value = 1, message = "수량은 1개 이상이어야 합니다")
-    private int quantity;
+public record CartUpdateRequest(
+        @Min(value = 1, message = "수량은 1개 이상이어야 합니다")
+        int quantity
+) {
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartUpdateResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/dto/CartUpdateResponse.java
@@ -1,23 +1,14 @@
 package com.spartafarmer.agri_commerce.domain.cart.dto;
 
-import lombok.Getter;
-
-// 수량 변경 dto
-@Getter
-public class CartUpdateResponse {
-    private final Long cartItemId;
-    private final Long productId;
-    private final String productName;
-    private final Long price;
-    private final int quantity;
-    private final Long totalPrice;
-
+public record CartUpdateResponse(
+        Long cartItemId,
+        Long productId,
+        String productName,
+        Long price,
+        int quantity,
+        Long totalPrice
+) {
     public CartUpdateResponse(Long cartItemId, Long productId, String productName, Long price, int quantity) {
-        this.cartItemId = cartItemId;
-        this.productId = productId;
-        this.productName = productName;
-        this.price = price;
-        this.quantity = quantity;
-        this.totalPrice = price * quantity;
+        this(cartItemId, productId, productName, price, quantity, price * quantity);
     }
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/entity/Cart.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/entity/Cart.java
@@ -26,7 +26,7 @@ public class Cart extends BaseEntity {
     private User user;
 
     @Getter(AccessLevel.NONE)
-    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CartItem> cartItems = new ArrayList<>();
 
     private Cart(User user) {
@@ -43,8 +43,22 @@ public class Cart extends BaseEntity {
         return Collections.unmodifiableList(cartItems);
     }
 
-    // 장바구니 상품 추가
+    // 장바구니 상품 추가(연관관계 편의 메서드)
     public void addCartItem(CartItem cartItem) {
         this.cartItems.add(cartItem);
+    }
+
+    // 장바구니 상품 삭제(개별)
+    // 유저가 장바구니 상품 삭제하는 것
+    // orphanRemoval = true에 의해 DB에서도 해당 CartItem이 삭제됨
+    public void removeCartItem(CartItem cartItem) {
+        this.cartItems.remove(cartItem);
+    }
+
+    // 장바구니 비우기 - 전체 delete
+    // 주문 완료 시 장바구니에 담긴 모든 상품을 제거하는 용도
+    // orphanRemoval = true에 의해 모든 CartItem이 DB에서 삭제됨
+    public void clearCartItems() {
+        this.cartItems.clear();
     }
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/entity/CartItem.java
@@ -6,17 +6,11 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "cart_items")
-@SQLDelete(sql = "UPDATE cart_items SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
-@Where(clause = "deleted_at IS NULL")
 public class CartItem extends BaseEntity {
 
     @Id
@@ -36,9 +30,6 @@ public class CartItem extends BaseEntity {
 
     @Column(nullable = false)
     private int quantity;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
 
     private CartItem(Cart cart, Product product, Long price, int quantity) {
         this.cart = cart;

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/repository/CartItemRepository.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
-    // @Where로 deleted_at IS NULL 자동 적용됨
     List<CartItem> findByCart(Cart cart);
 
     Optional<CartItem> findByCartAndProduct(Cart cart, Product product);

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/service/CartService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/service/CartService.java
@@ -36,10 +36,10 @@ public class CartService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 상품 조회
-        Product product = productRepository.findById(request.getProductId())
+        Product product = productRepository.findById(request.productId())
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
-        product.validateOrderable(request.getQuantity());
+        product.validateOrderable(request.quantity());
 
         // 장바구니 조회
         Cart cart = cartRepository.findByUser(user)
@@ -50,7 +50,7 @@ public class CartService {
                 .orElse(null);
 
         if (cartItem != null) {
-            int newQuantity = cartItem.getQuantity() + request.getQuantity();
+            int newQuantity = cartItem.getQuantity() + request.quantity();
 
             if (newQuantity > product.getStock()) {
                 throw new CustomException(ErrorCode.OUT_OF_STOCK);
@@ -68,7 +68,7 @@ public class CartService {
         }
 
         // 신규 생성
-        CartItem newItem = CartItem.create(cart, product, product.getSalePrice(), request.getQuantity());
+        CartItem newItem = CartItem.create(cart, product, product.getSalePrice(), request.quantity());
         cartItemRepository.save(newItem);
 
         return new CartAddResponse(
@@ -96,7 +96,7 @@ public class CartService {
                         item.getQuantity(),
                         item.getProduct().getStatus()
                 )).toList();
-        long totalPrice = items.stream().mapToLong(i -> i.getPrice() * i.getQuantity()).sum();
+        long totalPrice = items.stream().mapToLong(i -> i.price() * i.quantity()).sum();
         boolean isMinOrderAmountMet = totalPrice >= MIN_ORDER_AMOUNT;
         return new CartResponse(items, totalPrice, MIN_ORDER_AMOUNT, isMinOrderAmountMet);
     }
@@ -109,11 +109,11 @@ public class CartService {
 
 
         // 재고 초과 검증
-        if (request.getQuantity() > cartItem.getProduct().getStock()) {
+        if (request.quantity() > cartItem.getProduct().getStock()) {
             throw new CustomException(ErrorCode.OUT_OF_STOCK);
         }
 
-        cartItem.updateQuantity(request.getQuantity());
+        cartItem.updateQuantity(request.quantity());
         return new CartUpdateResponse(
                 cartItem.getId(),
                 cartItem.getProduct().getId(),

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/service/CartService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/service/CartService.java
@@ -1,6 +1,5 @@
 package com.spartafarmer.agri_commerce.domain.cart.service;
 
-import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
 import com.spartafarmer.agri_commerce.common.exception.CustomException;
 import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
 import com.spartafarmer.agri_commerce.domain.cart.dto.*;
@@ -88,7 +87,7 @@ public class CartService {
 
         Cart cart = cartRepository.findByUser(user)
                 .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
-        List< CartItemResponse> items = cart.getCartItems().stream()
+        List<CartItemResponse> items = cart.getCartItems().stream()
                 .map(item -> new CartItemResponse(
                         item.getId(),
                         item.getProduct().getId(),
@@ -121,10 +120,10 @@ public class CartService {
                 cartItem.getProduct().getName(),
                 cartItem.getPrice(),
                 cartItem.getQuantity()
-    );
+        );
     }
 
-    // 장바구니 삭제(소프트 딜리트)
+    // 장바구니 삭제
     @Transactional
     public void deleteCartItem(Long cartItemId, Long userId) {
 
@@ -132,17 +131,7 @@ public class CartService {
         CartItem cartItem = cartItemRepository.findByIdAndCart_User_Id(cartItemId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CART_ITEM_NOT_FOUND));
 
-        // Soft Delete 실행 (JPA가 update로 변환)
-        cartItemRepository.delete(cartItem);
-    }
-
-    // 상품 상태 검증
-    private void validateProductStatus(Product product) {
-        if (product.getStatus() == ProductStatus.SOLD_OUT) {
-            throw new CustomException(ErrorCode.PRODUCT_SOLD_OUT);
-        }
-        if (product.getStatus() == ProductStatus.SALE_ENDED) {
-            throw new CustomException(ErrorCode.PRODUCT_SALE_ENDED);
-        }
+        // Cart가 CartItem 생명주기를 관리하도록 부모 컬렉션에서 제거
+        cartItem.getCart().removeCartItem(cartItem);
     }
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/controller/OrderController.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/controller/OrderController.java
@@ -7,6 +7,7 @@ import com.spartafarmer.agri_commerce.domain.order.dto.OrderCreateResponse;
 import com.spartafarmer.agri_commerce.domain.order.dto.OrderListResponse;
 import com.spartafarmer.agri_commerce.domain.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,6 +22,7 @@ public class OrderController {
 
     // 주문 생성
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<OrderCreateResponse> createOrder(
             @AuthenticationPrincipal AuthUser authUser,
             @RequestBody OrderCreateRequest request

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/controller/OrderController.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/controller/OrderController.java
@@ -28,7 +28,7 @@ public class OrderController {
             @RequestBody OrderCreateRequest request
     ) {
         OrderCreateResponse response =
-                orderService.createOrder(authUser.getId(), request.getUserCouponId());
+                orderService.createOrder(authUser.getId(), request.userCouponId());
 
         return ApiResponse.success(
                 201,

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderCreateRequest.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderCreateRequest.java
@@ -1,11 +1,7 @@
 package com.spartafarmer.agri_commerce.domain.order.dto;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
-public class OrderCreateRequest {
-    // 쿠폰 미사용시 null
-    private Long userCouponId;
+public record OrderCreateRequest(
+        // 쿠폰 미사용시 null
+        Long userCouponId
+) {
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderCreateResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderCreateResponse.java
@@ -1,37 +1,15 @@
 package com.spartafarmer.agri_commerce.domain.order.dto;
 
-import lombok.Getter;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Getter
-public class OrderCreateResponse {
-
-    private final Long orderId;
-    private final List<OrderItemResponse> orderItems;
-
-    private final Long originalPrice;
-    private final Long discountAmount;
-    private final Long finalPrice;
-
-    private final String status;
-    private final LocalDateTime orderedAt;
-
-    public OrderCreateResponse(Long orderId,
-                               List<OrderItemResponse> orderItems,
-                               Long originalPrice,
-                               Long discountAmount,
-                               Long finalPrice,
-                               String status,
-                               LocalDateTime orderedAt) {
-
-        this.orderId = orderId;
-        this.orderItems = orderItems;
-        this.originalPrice = originalPrice;
-        this.discountAmount = discountAmount;
-        this.finalPrice = finalPrice;
-        this.status = status;
-        this.orderedAt = orderedAt;
-    }
+public record OrderCreateResponse(
+        Long orderId,
+        List<OrderItemResponse> orderItems,
+        Long originalPrice,
+        Long discountAmount,
+        Long finalPrice,
+        String status,
+        LocalDateTime orderedAt
+) {
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderItemResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderItemResponse.java
@@ -1,19 +1,9 @@
 package com.spartafarmer.agri_commerce.domain.order.dto;
 
-import lombok.Getter;
-
-@Getter
-public class OrderItemResponse {
-
-    private final String productName;
-    private final int quantity;
-    private final Long price;
-    private final Long totalPrice;
-
-    public OrderItemResponse(String productName, int quantity, Long price, Long totalPrice) {
-        this.productName = productName;
-        this.quantity = quantity;
-        this.price = price;
-        this.totalPrice = totalPrice;
-    }
+public record OrderItemResponse(
+        String productName,
+        int quantity,
+        Long price,
+        Long totalPrice
+) {
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderListResponse.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/dto/OrderListResponse.java
@@ -1,24 +1,13 @@
 package com.spartafarmer.agri_commerce.domain.order.dto;
 
-import lombok.Getter;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Getter
-public class OrderListResponse {
-
-    private final Long orderId;
-    private final List<OrderItemResponse> orderItems;
-    private final Long finalPrice;
-    private final String status;
-    private final LocalDateTime orderedAt;
-
-    public OrderListResponse(Long orderId, List<OrderItemResponse> orderItems, Long finalPrice, String status, LocalDateTime orderedAt) {
-        this.orderId = orderId;
-        this.orderItems = orderItems;
-        this.finalPrice = finalPrice;
-        this.status = status;
-        this.orderedAt = orderedAt;
-    }
+public record OrderListResponse(
+        Long orderId,
+        List<OrderItemResponse> orderItems,
+        Long finalPrice,
+        String status,
+        LocalDateTime orderedAt
+) {
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/service/OrderService.java
@@ -101,14 +101,12 @@ public class OrderService {
 
             product.decreaseStock(item.getQuantity());
 
-            OrderItem orderItem = OrderItem.create(
+            OrderItem.create(
                     order,
                     product,
                     product.getSalePrice(),
                     item.getQuantity()
             );
-
-            order.addOrderItem(orderItem);
         }
 
         orderRepository.save(order);
@@ -118,8 +116,8 @@ public class OrderService {
             userCoupon.use();
         }
 
-        // 장바구니 초기화
-        cart.getCartItems().clear();
+        // 주문 완료 후 장바구니 비우기
+        cart.clearCartItems();
 
         // 응답
         return new OrderCreateResponse(

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/service/OrderService.java
@@ -14,7 +14,6 @@ import com.spartafarmer.agri_commerce.domain.order.entity.Order;
 import com.spartafarmer.agri_commerce.domain.order.entity.OrderItem;
 import com.spartafarmer.agri_commerce.domain.order.repository.OrderRepository;
 import com.spartafarmer.agri_commerce.domain.product.entity.Product;
-import com.spartafarmer.agri_commerce.domain.product.repository.ProductRepository;
 import com.spartafarmer.agri_commerce.domain.user.entity.User;
 import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +30,6 @@ public class OrderService {
 
     private final UserRepository userRepository;
     private final CartRepository cartRepository;
-    private final ProductRepository productRepository;
     private final OrderRepository orderRepository;
     private final UserCouponRepository userCouponRepository;
 


### PR DESCRIPTION
📌 작업 내용
- 장바구니 삭제 정책 Soft Delete에서 Hard Delete로 변경
- Cart/Order DTO를 record로 전환


🔗 관련 이슈- close #74 


🧩 변경 사항- 주요 변경 내용
1. 장바구니 삭제 정책 변경
    - Soft Delete → Hard Delete로 변경
    - CartItem: deletedAt, @SQLDelete, @Where 제거
    - Cart: orphanRemoval 적용 및 CartItem 생명주기 관리하도록 구조 변경
    - 서비스 로직: repository delete → 도메인 메서드(removeCartItem, clearCartItems)로 변경
    - API: PATCH → DELETE로 변경

2. Cart DTO record 변환
3. Order DTO record 변환

🧪 테스트
- [ ] Postman 1차 테스트 완료
