### PR TITLE
feat: 쿠폰 발급 Redis 분산 락 적용 및 서비스 분리 (#136)

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponIssueService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponIssueService.java
@@ -1,0 +1,56 @@
+package com.spartafarmer.agri_commerce.domain.coupon.service;
+
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponIssueResponse;
+import com.spartafarmer.agri_commerce.domain.coupon.entity.Coupon;
+import com.spartafarmer.agri_commerce.domain.coupon.entity.UserCoupon;
+import com.spartafarmer.agri_commerce.domain.coupon.repository.CouponRepository;
+import com.spartafarmer.agri_commerce.domain.coupon.repository.UserCouponRepository;
+import com.spartafarmer.agri_commerce.domain.user.entity.User;
+import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class CouponIssueService {
+
+    // 기존 레포 3개 그대로 의존성
+    private final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
+    private final UserRepository userRepository;
+
+    // 락 획득 -> @Transactional -> 로직 -> 커밋 -> 락 해제
+    @Transactional
+    public CouponIssueResponse issueCoupon(Long couponId, Long userId) {
+
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COUPON_NOT_FOUND));
+
+        if (!coupon.isAvailableNow(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.COUPON_NOT_AVAILABLE_TIME);
+        }
+
+        if (userCouponRepository.existsByUserIdAndCouponId(userId, couponId)) {
+            throw new CustomException(ErrorCode.COUPON_ALREADY_ISSUED);
+        }
+
+        if (!coupon.hasRemaining()) {
+            throw new CustomException(ErrorCode.COUPON_SOLD_OUT);
+        }
+
+        coupon.increaseIssuedQuantity();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        UserCoupon userCoupon = UserCoupon.issue(user, coupon, LocalDateTime.now());
+        userCouponRepository.save(userCoupon);
+
+        return CouponIssueResponse.from(userCoupon);
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponService.java
@@ -2,23 +2,22 @@ package com.spartafarmer.agri_commerce.domain.coupon.service;
 
 import com.spartafarmer.agri_commerce.common.exception.CustomException;
 import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.common.lock.LockService;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.request.CouponCreateRequest;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponCreateResponse;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponIssueResponse;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.response.CouponListResponse;
 import com.spartafarmer.agri_commerce.domain.coupon.dto.response.UserCouponResponse;
 import com.spartafarmer.agri_commerce.domain.coupon.entity.Coupon;
-import com.spartafarmer.agri_commerce.domain.coupon.entity.UserCoupon;
 import com.spartafarmer.agri_commerce.domain.coupon.repository.CouponRepository;
 import com.spartafarmer.agri_commerce.domain.coupon.repository.UserCouponRepository;
-import com.spartafarmer.agri_commerce.domain.user.entity.User;
-import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -28,7 +27,8 @@ public class CouponService {
 
     private final CouponRepository couponRepository;
     private final UserCouponRepository userCouponRepository;
-    private final UserRepository userRepository;
+    private final LockService lockService;  // 락 잡는 용도
+    private final CouponIssueService couponIssueService;    // 실제 발급 로직 호출용
 
     // 쿠폰 생성 (관리자)
     @Transactional
@@ -73,39 +73,14 @@ public class CouponService {
                 .toList();
     }
 
-    @Transactional
+    // 트랜잭션은 CouponIssueService에 붙어 있기에 여기서는 락만 걸고 실제 발급 로직은 CouponIssueService에 위임
+    // 선착순 쿠폰 발급 (동시성 문제 해결 위해 락 사용)
     public CouponIssueResponse issueCoupon(Long couponId, Long userId) {
-
-        // 쿠폰 조회
-        Coupon coupon = couponRepository.findById(couponId)
-                .orElseThrow(() -> new CustomException(ErrorCode.COUPON_NOT_FOUND));
-
-        // 발급 기간 검증
-        if (!coupon.isAvailableNow(LocalDateTime.now())) {
-            throw new CustomException(ErrorCode.COUPON_NOT_AVAILABLE_TIME);
-        }
-
-        // 중복 발급 검증
-        if (userCouponRepository.existsByUserIdAndCouponId(userId, couponId)) {
-            throw new CustomException(ErrorCode.COUPON_ALREADY_ISSUED);
-        }
-
-        // 수량 검증
-        if (!coupon.hasRemaining()) {
-            throw new CustomException(ErrorCode.COUPON_SOLD_OUT);
-        }
-
-        // 발급 수량 증가
-        coupon.increaseIssuedQuantity();
-
-        // UserCoupon 생성, 저장
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        UserCoupon userCoupon = UserCoupon.issue(user, coupon, LocalDateTime.now());
-        userCouponRepository.save(userCoupon);
-
-        return CouponIssueResponse.from(userCoupon);
+        return lockService.executeWithLock(
+                "coupon:issue:" + couponId,
+                Duration.ofSeconds(3),  // TTL
+                () -> couponIssueService.issueCoupon(couponId, userId)
+        );
     }
 
 }


### PR DESCRIPTION
📌 작업 내용
쿠폰 발급에 Redis 분산 락 적용 + 서비스 클래스 분리

close #136 

🧩 상세 작업
- [x] CouponService에서 발급 로직을 CouponIssueService로 분리
  - CouponService: 락만 잡고 CouponIssueService 호출
  - CouponIssueService: 발급 검증, 수량 증가, UserCoupon 저장 (@Transactional)
- [x] 같은 클래스 내부 호출 시 @Transactional 프록시 안 타는 문제 해결
- [x] 락 key: coupon:issue:{couponId}
- [x] Fail Fast 전략 (락 못 잡으면 즉시 실패)
- [x] 순서: 락 획득 → 트랜잭션 → 로직 → 커밋 → 락 해제

✅ 1차 테스트 완료 기준
- [x] 빌드 성공
