### PR TITLE
feat: 주문 재고 차감 동시성 제어 (Redis 분산 락)

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/common/lock/LockService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/common/lock/LockService.java
@@ -6,6 +6,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -31,6 +34,29 @@ public class LockService {
         } finally {
             // 작업이 끝나거나 예외 처리 되면 락 풀기
             redisLockRepository.unlock(key, uuid);
+        }
+    }
+
+    // 다중 락
+    public <T> T executeWithLocks(List<String> keys, Duration ttl, Supplier<T> task) {
+        String uuid = UUID.randomUUID().toString();
+        List<String> lockedKeys = new ArrayList<>();
+
+        try {
+            for (String key : keys) {
+                boolean locked = redisLockRepository.tryLock(key, uuid, ttl);
+                if (!locked) {
+                    throw new CustomException(ErrorCode.LOCK_ACQUIRE_FAILED);
+                }
+                lockedKeys.add(key);
+            }
+
+            return task.get();
+        } finally {
+            Collections.reverse(lockedKeys);
+            for (String key : lockedKeys) {
+                redisLockRepository.unlock(key, uuid);
+            }
         }
     }
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/repository/CartRepository.java
@@ -3,10 +3,15 @@ package com.spartafarmer.agri_commerce.domain.cart.repository;
 import com.spartafarmer.agri_commerce.domain.cart.entity.Cart;
 import com.spartafarmer.agri_commerce.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
     Optional<Cart> findByUser(User user);
+
+    @Query("SELECT c FROM Cart c JOIN FETCH c.cartItems ci JOIN FETCH ci.product WHERE c.user = :user")
+    Optional<Cart> findByUserWithItems(@Param("user") User user);
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/service/OrderCreateService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/service/OrderCreateService.java
@@ -1,0 +1,127 @@
+package com.spartafarmer.agri_commerce.domain.order.service;
+
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.domain.cart.entity.Cart;
+import com.spartafarmer.agri_commerce.domain.cart.entity.CartItem;
+import com.spartafarmer.agri_commerce.domain.cart.repository.CartRepository;
+import com.spartafarmer.agri_commerce.domain.coupon.entity.UserCoupon;
+import com.spartafarmer.agri_commerce.domain.coupon.repository.UserCouponRepository;
+import com.spartafarmer.agri_commerce.domain.order.dto.OrderCreateResponse;
+import com.spartafarmer.agri_commerce.domain.order.dto.OrderItemResponse;
+import com.spartafarmer.agri_commerce.domain.order.entity.Order;
+import com.spartafarmer.agri_commerce.domain.order.entity.OrderItem;
+import com.spartafarmer.agri_commerce.domain.order.repository.OrderRepository;
+import com.spartafarmer.agri_commerce.domain.product.entity.Product;
+import com.spartafarmer.agri_commerce.domain.user.entity.User;
+import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OrderCreateService {
+
+    private final UserRepository userRepository;
+    private final CartRepository cartRepository;
+    private final OrderRepository orderRepository;
+    private final UserCouponRepository userCouponRepository;
+
+    public OrderCreateResponse createOrder(Long userId, Long userCouponId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Cart cart = cartRepository.findByUser(user)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
+
+        List<CartItem> cartItems = cart.getCartItems();
+
+        if (cartItems.isEmpty()) {
+            throw new CustomException(ErrorCode.CART_EMPTY);
+        }
+
+        long totalPrice = 0L;
+        boolean hasCoupon = (userCouponId != null);
+
+        // 상품 검증 + 금액 계산
+        for (CartItem item : cartItems) {
+            Product product = item.getProduct();
+
+            product.validateOrderable(item.getQuantity());
+
+            if (hasCoupon && product.getSpecialPrice() != null) {
+                throw new CustomException(ErrorCode.COUPON_NOT_APPLICABLE);
+            }
+
+            totalPrice += product.getSalePrice() * item.getQuantity();
+        }
+
+        // 쿠폰 처리
+        UserCoupon userCoupon = null;
+        long discountPrice = 0L;
+
+        if (hasCoupon) {
+            userCoupon = userCouponRepository.findById(userCouponId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.COUPON_NOT_FOUND));
+
+            userCoupon.validateUsable(LocalDateTime.now());
+            discountPrice = userCoupon.getCoupon().getDiscountAmount();
+        }
+
+        long finalPrice = totalPrice - discountPrice;
+
+        if (finalPrice < 20000) {
+            throw new CustomException(ErrorCode.MIN_ORDER_AMOUNT_NOT_MET);
+        }
+
+        // 주문 생성
+        Order order = Order.create(user, userCoupon, totalPrice, discountPrice, finalPrice);
+
+        // 주문 아이템 + 재고 차감
+        for (CartItem item : cartItems) {
+            Product product = item.getProduct();
+
+            product.decreaseStock(item.getQuantity());
+
+            OrderItem.create(
+                    order,
+                    product,
+                    product.getSalePrice(),
+                    item.getQuantity()
+            );
+        }
+
+        orderRepository.save(order);
+
+        // 쿠폰 사용 처리
+        if (userCoupon != null) {
+            userCoupon.use();
+        }
+
+        // 주문 완료 후 장바구니 비우기
+        cart.clearCartItems();
+
+        return new OrderCreateResponse(
+                order.getId(),
+                order.getOrderItems().stream()
+                        .map(i -> new OrderItemResponse(
+                                i.getProduct().getName(),
+                                i.getQuantity(),
+                                i.getPrice(),
+                                i.getPrice() * i.getQuantity()
+                        ))
+                        .toList(),
+                order.getTotalPrice(),
+                order.getDiscountPrice(),
+                order.getFinalPrice(),
+                order.getStatus().name(),
+                order.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/service/OrderService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/service/OrderService.java
@@ -2,38 +2,34 @@ package com.spartafarmer.agri_commerce.domain.order.service;
 
 import com.spartafarmer.agri_commerce.common.exception.CustomException;
 import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.common.lock.LockService;
 import com.spartafarmer.agri_commerce.domain.cart.entity.Cart;
-import com.spartafarmer.agri_commerce.domain.cart.entity.CartItem;
 import com.spartafarmer.agri_commerce.domain.cart.repository.CartRepository;
-import com.spartafarmer.agri_commerce.domain.coupon.entity.UserCoupon;
-import com.spartafarmer.agri_commerce.domain.coupon.repository.UserCouponRepository;
 import com.spartafarmer.agri_commerce.domain.order.dto.OrderCreateResponse;
 import com.spartafarmer.agri_commerce.domain.order.dto.OrderItemResponse;
 import com.spartafarmer.agri_commerce.domain.order.dto.OrderListResponse;
 import com.spartafarmer.agri_commerce.domain.order.entity.Order;
-import com.spartafarmer.agri_commerce.domain.order.entity.OrderItem;
 import com.spartafarmer.agri_commerce.domain.order.repository.OrderRepository;
-import com.spartafarmer.agri_commerce.domain.product.entity.Product;
 import com.spartafarmer.agri_commerce.domain.user.entity.User;
 import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Duration;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class OrderService {
 
     private final UserRepository userRepository;
     private final CartRepository cartRepository;
     private final OrderRepository orderRepository;
-    private final UserCouponRepository userCouponRepository;
+    private final LockService lockService;
+    private final OrderCreateService orderCreateService;
 
-    // 장바구니 전체 주문 생성
+    // 장바구니 전체 주문 생성 (락)
     public OrderCreateResponse createOrder(Long userId, Long userCouponId) {
 
         // 유저 조회
@@ -41,98 +37,18 @@ public class OrderService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 장바구니 조회
-        Cart cart = cartRepository.findByUser(user)
+        Cart cart = cartRepository.findByUserWithItems(user)
                 .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
 
-        List<CartItem> cartItems = cart.getCartItems();
+        List<String> keys = cart.getCartItems().stream()
+                .map(item -> item.getProduct().getId())
+                .distinct().sorted().map(productId -> "product:stock:" + productId)
+                .toList();
 
-        if (cartItems.isEmpty()) {
-            throw new CustomException(ErrorCode.CART_EMPTY);
-        }
-
-        long totalPrice = 0L;
-        boolean hasCoupon = (userCouponId != null);
-
-        // 상품 검증 + 금액 계산
-        for (CartItem item : cartItems) {
-
-            Product product = item.getProduct();
-
-            product.validateOrderable(item.getQuantity());
-
-            // 특가 + 쿠폰 제한
-            if (hasCoupon && product.getSpecialPrice() != null) {
-                throw new CustomException(ErrorCode.COUPON_NOT_APPLICABLE);
-            }
-
-            totalPrice += product.getSalePrice() * item.getQuantity();
-        }
-
-        // 쿠폰 처리
-        UserCoupon userCoupon = null;
-        long discountPrice = 0L;
-
-        if (hasCoupon) {
-
-            userCoupon = userCouponRepository.findById(userCouponId)
-                    .orElseThrow(() -> new CustomException(ErrorCode.COUPON_NOT_FOUND));
-
-            userCoupon.validateUsable(LocalDateTime.now());
-
-            discountPrice = userCoupon.getCoupon().getDiscountAmount();
-        }
-
-        long finalPrice = totalPrice - discountPrice;
-
-        // 최소 주문 금액
-        if (finalPrice < 20000) {
-            throw new CustomException(ErrorCode.MIN_ORDER_AMOUNT_NOT_MET);
-        }
-
-        //  주문 생성
-        Order order = Order.create(user, userCoupon, totalPrice, discountPrice, finalPrice);
-
-        // 주문 아이템 + 재고 차감
-        for (CartItem item : cartItems) {
-
-            Product product = item.getProduct();
-
-            product.decreaseStock(item.getQuantity());
-
-            OrderItem.create(
-                    order,
-                    product,
-                    product.getSalePrice(),
-                    item.getQuantity()
-            );
-        }
-
-        orderRepository.save(order);
-
-        // 쿠폰 사용 처리
-        if (userCoupon != null) {
-            userCoupon.use();
-        }
-
-        // 주문 완료 후 장바구니 비우기
-        cart.clearCartItems();
-
-        // 응답
-        return new OrderCreateResponse(
-                order.getId(),
-                order.getOrderItems().stream()
-                        .map(i -> new OrderItemResponse(
-                                i.getProduct().getName(),
-                                i.getQuantity(),
-                                i.getPrice(),
-                                i.getPrice() * i.getQuantity()
-                        ))
-                        .toList(),
-                order.getTotalPrice(),
-                order.getDiscountPrice(),
-                order.getFinalPrice(),
-                order.getStatus().name(),
-                order.getCreatedAt()
+        return lockService.executeWithLocks(
+                keys,
+                Duration.ofSeconds(3),
+                () -> orderCreateService.createOrder(userId, userCouponId)
         );
     }
 


### PR DESCRIPTION
📌 작업 내용
주문 재고 차감 동시성 제어


🔗 관련 이슈- close #133 


🧩 변경 사항

 Redis 분산 락 적용 (Lettuce 기반, SETNX + TTL + Lua Script)
- Fail Fast 전략 - 락 획득 실패 시 즉시 예외 반환 (TTL 3초)
- Lock Key: `product:stock:{productId}` 상품 단위 경합 제어
- 다중 상품 주문 시 락 키 정렬로 데드락 방지
- 트랜잭션 범위 분리: OrderService(락) → OrderCreateService(트랜잭션 + 로직)
  - @Transactional이 외부 호출(프록시)에서만 동작하기 때문에 같은 클래스 내부 호출 시 트랜잭션이 무시되는 문제를 방지하기 위해 클래스 분리


🧪 테스트
- [x] Postman 1차 테스트 완료

- [ ] 단위 테스트 완료 (해당 시)


🔥 리뷰 요청
 락 획득 → 트랜잭션 시작 → 커밋 → 락 해제 순서로 동작하는지 확인.
