### PR TITLE
feat: 주문 도메인 단위 테스트

### DIFF
--- a/src/test/java/com/spartafarmer/agri_commerce/order/OrderControllerTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/order/OrderControllerTest.java
@@ -4,22 +4,25 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spartafarmer.agri_commerce.common.enums.UserRole;
 import com.spartafarmer.agri_commerce.common.exception.CustomException;
 import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.common.security.AuthUser;
 import com.spartafarmer.agri_commerce.common.security.JwtUtil;
+import com.spartafarmer.agri_commerce.domain.order.controller.OrderController;
 import com.spartafarmer.agri_commerce.domain.order.dto.OrderCreateRequest;
 import com.spartafarmer.agri_commerce.domain.order.dto.OrderCreateResponse;
 import com.spartafarmer.agri_commerce.domain.order.dto.OrderListResponse;
 import com.spartafarmer.agri_commerce.domain.order.service.OrderService;
-import com.spartafarmer.agri_commerce.domain.user.entity.User;
-import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,35 +35,30 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
+@WebMvcTest(controllers = OrderController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class OrderControllerTest {
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
-    @Autowired JwtUtil jwtUtil;
-    @Autowired UserRepository userRepository;
 
-    @MockitoBean
-    OrderService orderService;
-
-    private User user;
-    private String token;
+    @MockitoBean OrderService orderService;
+    @MockitoBean JpaMetamodelMappingContext jpaMetamodelMappingContext;
+    @MockitoBean JwtUtil jwtUtil;
 
     @BeforeEach
     void setUp() {
-        user = userRepository.save(
-                User.create(
-                        "order_ctrl@test.com",
-                        "Password123",
-                        "주문유저",
-                        User.formatPhone("01011112222"),
-                        "서울시",
-                        UserRole.USER
-                )
+        // @AuthenticationPrincipal 주입을 위한 SecurityContext 세팅
+        AuthUser authUser = new AuthUser(1L, "test@test.com", UserRole.USER);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities())
         );
-        token = jwtUtil.createToken(user.getId(), user.getEmail(), user.getRole());
+    }
+
+    // 다음 테스트에 인증 정보 남지 않도록 초기화
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -73,7 +71,6 @@ class OrderControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/orders")
-                        .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new OrderCreateRequest(null))))
                 .andExpect(status().isCreated())
@@ -90,7 +87,6 @@ class OrderControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/orders")
-                        .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new OrderCreateRequest(null))))
                 .andExpect(status().isNotFound())
@@ -106,7 +102,6 @@ class OrderControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/orders")
-                        .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new OrderCreateRequest(null))))
                 .andExpect(status().isBadRequest())
@@ -121,8 +116,7 @@ class OrderControllerTest {
         given(orderService.getOrders(anyLong())).willReturn(List.of(response));
 
         // when & then
-        mockMvc.perform(get("/api/orders")
-                        .header("Authorization", "Bearer " + token))
+        mockMvc.perform(get("/api/orders"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.data.length()").value(1))
@@ -136,8 +130,7 @@ class OrderControllerTest {
                 .willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // when & then
-        mockMvc.perform(get("/api/orders")
-                        .header("Authorization", "Bearer " + token))
+        mockMvc.perform(get("/api/orders"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.message").value("회원을 찾을 수 없습니다."));

--- a/src/test/java/com/spartafarmer/agri_commerce/order/OrderControllerTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/order/OrderControllerTest.java
@@ -1,0 +1,129 @@
+package com.spartafarmer.agri_commerce.order;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spartafarmer.agri_commerce.common.enums.UserRole;
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.common.security.JwtUtil;
+import com.spartafarmer.agri_commerce.domain.order.dto.OrderCreateRequest;
+import com.spartafarmer.agri_commerce.domain.order.dto.OrderCreateResponse;
+import com.spartafarmer.agri_commerce.domain.order.dto.OrderListResponse;
+import com.spartafarmer.agri_commerce.domain.order.service.OrderService;
+import com.spartafarmer.agri_commerce.domain.user.entity.User;
+import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class OrderControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired JwtUtil jwtUtil;
+    @Autowired UserRepository userRepository;
+
+    @MockitoBean
+    OrderService orderService;
+
+    private User user;
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(
+                User.create(
+                        "order_ctrl@test.com",
+                        "Password123",
+                        "주문유저",
+                        User.formatPhone("01011112222"),
+                        "서울시",
+                        UserRole.USER
+                )
+        );
+        token = jwtUtil.createToken(user.getId(), user.getEmail(), user.getRole());
+    }
+
+    @Test
+    void 주문생성_성공() throws Exception {
+        // given
+        OrderCreateResponse response = new OrderCreateResponse(
+                1L, List.of(), 25000L, 0L, 25000L, "COMPLETED", LocalDateTime.now()
+        );
+        given(orderService.createOrder(anyLong(), isNull())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/orders")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new OrderCreateRequest(null))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.data.finalPrice").value(25000))
+                .andExpect(jsonPath("$.data.status").value("COMPLETED"));
+    }
+
+    @Test
+    void 주문생성_실패_장바구니없음() throws Exception {
+        // given
+        given(orderService.createOrder(anyLong(), isNull()))
+                .willThrow(new CustomException(ErrorCode.CART_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(post("/api/orders")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new OrderCreateRequest(null))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("장바구니를 찾을 수 없습니다."));
+    }
+
+    @Test
+    void 주문목록조회_성공() throws Exception {
+        // given
+        OrderListResponse response = new OrderListResponse(1L, List.of(), 25000L, "COMPLETED", LocalDateTime.now());
+        given(orderService.getOrders(anyLong())).willReturn(List.of(response));
+
+        // when & then
+        mockMvc.perform(get("/api/orders")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].finalPrice").value(25000));
+    }
+
+    @Test
+    void 주문목록조회_실패_유저없음() throws Exception {
+        // given
+        given(orderService.getOrders(anyLong()))
+                .willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/orders")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("회원을 찾을 수 없습니다."));
+    }
+}

--- a/src/test/java/com/spartafarmer/agri_commerce/order/OrderControllerTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/order/OrderControllerTest.java
@@ -99,6 +99,22 @@ class OrderControllerTest {
     }
 
     @Test
+    void 주문생성_실패_최소주문금액미만() throws Exception {
+        // given
+        given(orderService.createOrder(anyLong(), isNull()))
+                .willThrow(new CustomException(ErrorCode.MIN_ORDER_AMOUNT_NOT_MET));
+
+        // when & then
+        mockMvc.perform(post("/api/orders")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new OrderCreateRequest(null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("최소 주문 금액은 20,000원 이상입니다."));
+    }
+
+    @Test
     void 주문목록조회_성공() throws Exception {
         // given
         OrderListResponse response = new OrderListResponse(1L, List.of(), 25000L, "COMPLETED", LocalDateTime.now());

--- a/src/test/java/com/spartafarmer/agri_commerce/order/OrderServiceTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/order/OrderServiceTest.java
@@ -1,5 +1,8 @@
 package com.spartafarmer.agri_commerce.order;
 
+import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
+import com.spartafarmer.agri_commerce.common.enums.ProductType;
+import com.spartafarmer.agri_commerce.common.enums.UserRole;
 import com.spartafarmer.agri_commerce.common.exception.CustomException;
 import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
 import com.spartafarmer.agri_commerce.common.lock.LockService;
@@ -9,7 +12,7 @@ import com.spartafarmer.agri_commerce.domain.cart.repository.CartRepository;
 import com.spartafarmer.agri_commerce.domain.order.dto.OrderCreateResponse;
 import com.spartafarmer.agri_commerce.domain.order.dto.OrderListResponse;
 import com.spartafarmer.agri_commerce.domain.order.entity.Order;
-import com.spartafarmer.agri_commerce.domain.order.entity.OrderStatus;
+import com.spartafarmer.agri_commerce.domain.order.entity.OrderItem;
 import com.spartafarmer.agri_commerce.domain.order.repository.OrderRepository;
 import com.spartafarmer.agri_commerce.domain.order.service.OrderCreateService;
 import com.spartafarmer.agri_commerce.domain.order.service.OrderService;
@@ -32,7 +35,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class OrderServiceTest {
@@ -58,19 +60,25 @@ class OrderServiceTest {
     @Test
     void 주문생성_성공() {
         // given
-        User user = mock(User.class);
-        Cart cart = mock(Cart.class);
-        CartItem cartItem = mock(CartItem.class);
-        Product product = mock(Product.class);
+        User user = User.create(
+                "test@test.com", "pass1234", "테스트유저",
+                "010-1234-5678", "서울", UserRole.USER
+        );
+
+        Product product = Product.create(
+                "사과", ProductType.NORMAL,
+                15000L, 12000L, null,
+                10, ProductStatus.ON_SALE, null
+        );
+
+        Cart cart = Cart.create(user);
+        CartItem.create(cart, product, product.getSalePrice(), 2);
 
         given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
         given(cartRepository.findByUserWithItems(user)).willReturn(Optional.of(cart));
-        given(cart.getCartItems()).willReturn(List.of(cartItem));
-        given(cartItem.getProduct()).willReturn(product);
-        given(product.getId()).willReturn(1L);
 
         OrderCreateResponse expected = new OrderCreateResponse(
-                1L, List.of(), 25000L, 0L, 25000L, "COMPLETED", LocalDateTime.now()
+                1L, List.of(), 24000L, 0L, 24000L, "COMPLETED", LocalDateTime.now()
         );
         given(lockService.executeWithLocks(anyList(), any(), any())).willReturn(expected);
 
@@ -78,7 +86,7 @@ class OrderServiceTest {
         OrderCreateResponse result = orderService.createOrder(1L, null);
 
         // then
-        assertThat(result.finalPrice()).isEqualTo(25000L);
+        assertThat(result.finalPrice()).isEqualTo(24000L);
         assertThat(result.status()).isEqualTo("COMPLETED");
     }
 
@@ -97,7 +105,10 @@ class OrderServiceTest {
     @Test
     void 주문생성_실패_장바구니없음() {
         // given
-        User user = mock(User.class);
+        User user = User.create(
+                "test@test.com", "pass1234", "테스트유저",
+                "010-1234-5678", "서울", UserRole.USER
+        );
 
         given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
         given(cartRepository.findByUserWithItems(user)).willReturn(Optional.empty());
@@ -112,16 +123,22 @@ class OrderServiceTest {
     @Test
     void 주문목록조회_성공() {
         // given
-        User user = mock(User.class);
-        Order order = mock(Order.class);
+        User user = User.create(
+                "test@test.com", "pass1234", "테스트유저",
+                "010-1234-5678", "서울", UserRole.USER
+        );
+
+        Product product = Product.create(
+                "사과", ProductType.NORMAL,
+                15000L, 12000L, null,
+                10, ProductStatus.ON_SALE, null
+        );
+
+        Order order = Order.create(user, null, 25000L, 0L, 25000L);
+        OrderItem.create(order, product, product.getSalePrice(), 2);
 
         given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
         given(orderRepository.findAllByUserIdOrderByCreatedAtDesc(anyLong())).willReturn(List.of(order));
-        given(order.getId()).willReturn(1L);
-        given(order.getOrderItems()).willReturn(List.of());
-        given(order.getFinalPrice()).willReturn(25000L);
-        given(order.getStatus()).willReturn(OrderStatus.COMPLETED);
-        given(order.getCreatedAt()).willReturn(LocalDateTime.now());
 
         // when
         List<OrderListResponse> result = orderService.getOrders(1L);
@@ -130,6 +147,8 @@ class OrderServiceTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).finalPrice()).isEqualTo(25000L);
         assertThat(result.get(0).status()).isEqualTo("COMPLETED");
+        assertThat(result.get(0).orderItems()).hasSize(1);
+        assertThat(result.get(0).orderItems().get(0).productName()).isEqualTo("사과");
     }
 
     @Test

--- a/src/test/java/com/spartafarmer/agri_commerce/order/OrderServiceTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/order/OrderServiceTest.java
@@ -1,0 +1,146 @@
+package com.spartafarmer.agri_commerce.order;
+
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.common.lock.LockService;
+import com.spartafarmer.agri_commerce.domain.cart.entity.Cart;
+import com.spartafarmer.agri_commerce.domain.cart.entity.CartItem;
+import com.spartafarmer.agri_commerce.domain.cart.repository.CartRepository;
+import com.spartafarmer.agri_commerce.domain.order.dto.OrderCreateResponse;
+import com.spartafarmer.agri_commerce.domain.order.dto.OrderListResponse;
+import com.spartafarmer.agri_commerce.domain.order.entity.Order;
+import com.spartafarmer.agri_commerce.domain.order.entity.OrderStatus;
+import com.spartafarmer.agri_commerce.domain.order.repository.OrderRepository;
+import com.spartafarmer.agri_commerce.domain.order.service.OrderCreateService;
+import com.spartafarmer.agri_commerce.domain.order.service.OrderService;
+import com.spartafarmer.agri_commerce.domain.product.entity.Product;
+import com.spartafarmer.agri_commerce.domain.user.entity.User;
+import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CartRepository cartRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private LockService lockService;
+
+    @Mock
+    private OrderCreateService orderCreateService;
+
+    @Test
+    void 주문생성_성공() {
+        // given
+        User user = mock(User.class);
+        Cart cart = mock(Cart.class);
+        CartItem cartItem = mock(CartItem.class);
+        Product product = mock(Product.class);
+
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        given(cartRepository.findByUserWithItems(user)).willReturn(Optional.of(cart));
+        given(cart.getCartItems()).willReturn(List.of(cartItem));
+        given(cartItem.getProduct()).willReturn(product);
+        given(product.getId()).willReturn(1L);
+
+        OrderCreateResponse expected = new OrderCreateResponse(
+                1L, List.of(), 25000L, 0L, 25000L, "COMPLETED", LocalDateTime.now()
+        );
+        given(lockService.executeWithLocks(anyList(), any(), any())).willReturn(expected);
+
+        // when
+        OrderCreateResponse result = orderService.createOrder(1L, null);
+
+        // then
+        assertThat(result.finalPrice()).isEqualTo(25000L);
+        assertThat(result.status()).isEqualTo("COMPLETED");
+    }
+
+    @Test
+    void 주문생성_실패_유저없음() {
+        // given
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.createOrder(1L, null))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Test
+    void 주문생성_실패_장바구니없음() {
+        // given
+        User user = mock(User.class);
+
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        given(cartRepository.findByUserWithItems(user)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.createOrder(1L, null))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.CART_NOT_FOUND));
+    }
+
+    @Test
+    void 주문목록조회_성공() {
+        // given
+        User user = mock(User.class);
+        Order order = mock(Order.class);
+
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        given(orderRepository.findAllByUserIdOrderByCreatedAtDesc(anyLong())).willReturn(List.of(order));
+        given(order.getId()).willReturn(1L);
+        given(order.getOrderItems()).willReturn(List.of());
+        given(order.getFinalPrice()).willReturn(25000L);
+        given(order.getStatus()).willReturn(OrderStatus.COMPLETED);
+        given(order.getCreatedAt()).willReturn(LocalDateTime.now());
+
+        // when
+        List<OrderListResponse> result = orderService.getOrders(1L);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).finalPrice()).isEqualTo(25000L);
+        assertThat(result.get(0).status()).isEqualTo("COMPLETED");
+    }
+
+    @Test
+    void 주문목록조회_실패_유저없음() {
+        // given
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.getOrders(1L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/test/java/com/spartafarmer/agri_commerce/order/OrderServiceTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/order/OrderServiceTest.java
@@ -121,6 +121,35 @@ class OrderServiceTest {
     }
 
     @Test
+    void 주문생성_실패_최소주문금액미만() {
+        // given
+        User user = User.create(
+                "test@test.com", "pass1234", "테스트유저",
+                "010-1234-5678", "서울", UserRole.USER
+        );
+
+        Product product = Product.create(
+                "사과", ProductType.NORMAL,
+                10000L, 8000L, null,
+                10, ProductStatus.ON_SALE, null
+        );
+
+        Cart cart = Cart.create(user);
+        CartItem.create(cart, product, product.getSalePrice(), 1);
+
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        given(cartRepository.findByUserWithItems(user)).willReturn(Optional.of(cart));
+        given(lockService.executeWithLocks(anyList(), any(), any()))
+                .willThrow(new CustomException(ErrorCode.MIN_ORDER_AMOUNT_NOT_MET));
+
+        // when & then
+        assertThatThrownBy(() -> orderService.createOrder(1L, null))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.MIN_ORDER_AMOUNT_NOT_MET));
+    }
+
+    @Test
     void 주문목록조회_성공() {
         // given
         User user = User.create(


### PR DESCRIPTION
📌 작업 내용
주문 도메인 교차 단위 테스트 작성 (OrderService, OrderController)

🔗 관련 이슈
close #117

🧩 변경 사항
- OrderServiceTest 작성 (주문 생성/목록 조회 총 5개 케이스)
  - Mockito 기반 단위 테스트로 Repository 및 의존 서비스 Mock 처리
- OrderControllerTest 작성 (주문 생성/목록 조회 총 4개 케이스)
  - @SpringBootTest + @AutoConfigureMockMvc 방식, OrderService는 @MockitoBean으로 대체
  - JWT 토큰 발급 후 헤더 인증 방식으로 요청 검증

🧪 테스트
- [x] 단위 테스트 완료 (해당 시)


🔥 리뷰 요청 (있으면 작성)- 중점적으로 봐줬으면 하는 부분 1개
