### PR TITLE
feat:상품 단위 테스트 작성

### DIFF
--- a/src/test/java/com/spartafarmer/agri_commerce/product/PopularSearchControllerTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/product/PopularSearchControllerTest.java
@@ -1,0 +1,55 @@
+package com.spartafarmer.agri_commerce.product;
+
+import com.spartafarmer.agri_commerce.common.security.JwtUtil;
+import com.spartafarmer.agri_commerce.domain.product.controller.PopularSearchController;
+import com.spartafarmer.agri_commerce.domain.product.dto.PopularKeywordResponse;
+import com.spartafarmer.agri_commerce.domain.product.service.PopularSearchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = PopularSearchController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("인기검색어 컨트롤러 테스트")
+class PopularSearchControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    PopularSearchService popularSearchService;
+
+    @MockitoBean
+    JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    JwtUtil jwtUtil;
+
+    @Test
+    @DisplayName("성공: 인기검색어 조회")
+    void 인기검색어_조회_성공() throws Exception {
+        // given
+        given(popularSearchService.getTopKeywords()).willReturn(List.of(
+                new PopularKeywordResponse(1, "딸기", 10L),
+                new PopularKeywordResponse(2, "감귤", 8L)
+        ));
+
+        // when & then
+        mockMvc.perform(get("/api/products/search/popular"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].rank").value(1))
+                .andExpect(jsonPath("$[0].keyword").value("딸기"))
+                .andExpect(jsonPath("$[0].searchCount").value(10));
+    }
+}

--- a/src/test/java/com/spartafarmer/agri_commerce/product/ProductControllerTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/product/ProductControllerTest.java
@@ -1,0 +1,113 @@
+package com.spartafarmer.agri_commerce.product;
+
+import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
+import com.spartafarmer.agri_commerce.common.enums.ProductType;
+import com.spartafarmer.agri_commerce.common.security.JwtUtil;
+import com.spartafarmer.agri_commerce.domain.product.controller.ProductController;
+import com.spartafarmer.agri_commerce.domain.product.dto.ProductDetailResponse;
+import com.spartafarmer.agri_commerce.domain.product.dto.ProductListResponse;
+import com.spartafarmer.agri_commerce.domain.product.service.ProductService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ProductController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("상품 컨트롤러 테스트")
+class ProductControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    ProductService productService;
+
+    @MockitoBean
+    JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    JwtUtil jwtUtil;
+
+    @Test
+    @DisplayName("성공: 전체 상품 목록 조회")
+    void 상품_목록_조회_성공() throws Exception {
+        // given
+        ProductListResponse response1 = new ProductListResponse(
+                1L, "제주 감귤", ProductType.NORMAL,
+                15000L, 12000L, null,
+                100, ProductStatus.ON_SALE, null, LocalDateTime.now()
+        );
+        ProductListResponse response2 = new ProductListResponse(
+                2L, "한우 특가", ProductType.SPECIAL,
+                50000L, 50000L, 30000L,
+                20, ProductStatus.ON_SALE, null, LocalDateTime.now()
+        );
+
+        given(productService.getProducts(eq(null), any()))
+                .willReturn(new PageImpl<>(List.of(response1, response2), PageRequest.of(0, 10), 2));
+
+        // when & then
+        mockMvc.perform(get("/api/products"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].name").value("제주 감귤"))
+                .andExpect(jsonPath("$.content[0].type").value("NORMAL"))
+                .andExpect(jsonPath("$.content[1].name").value("한우 특가"))
+                .andExpect(jsonPath("$.content[1].type").value("SPECIAL"));
+    }
+
+    @Test
+    @DisplayName("성공: 특가 상품 목록 조회")
+    void 특가_상품_목록_조회_성공() throws Exception {
+        // given
+        ProductListResponse response = new ProductListResponse(
+                2L, "한우 특가", ProductType.SPECIAL,
+                50000L, 50000L, 30000L,
+                20, ProductStatus.ON_SALE, null, LocalDateTime.now()
+        );
+
+        given(productService.getProducts(eq(ProductType.SPECIAL), any()))
+                .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1));
+
+        // when & then
+        mockMvc.perform(get("/api/products")
+                        .param("type", "SPECIAL"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].name").value("한우 특가"))
+                .andExpect(jsonPath("$.content[0].type").value("SPECIAL"));
+    }
+
+    @Test
+    @DisplayName("성공: 상품 상세 조회")
+    void 상품_상세_조회_성공() throws Exception {
+        // given
+        ProductDetailResponse response = new ProductDetailResponse(
+                1L, "제주 감귤", ProductType.NORMAL, ProductStatus.ON_SALE,
+                15000L, 12000L, null, 100, null, LocalDateTime.now()
+        );
+
+        given(productService.getProduct(1L)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/products/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("제주 감귤"))
+                .andExpect(jsonPath("$.type").value("NORMAL"))
+                .andExpect(jsonPath("$.status").value("ON_SALE"));
+    }
+}

--- a/src/test/java/com/spartafarmer/agri_commerce/product/ProductSearchControllerTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/product/ProductSearchControllerTest.java
@@ -1,0 +1,82 @@
+package com.spartafarmer.agri_commerce.product;
+
+import com.spartafarmer.agri_commerce.common.security.JwtUtil;
+import com.spartafarmer.agri_commerce.domain.product.controller.ProductSearchController;
+import com.spartafarmer.agri_commerce.domain.product.dto.ProductListResponse;
+import com.spartafarmer.agri_commerce.domain.product.service.ProductService;
+import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
+import com.spartafarmer.agri_commerce.common.enums.ProductType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ProductSearchController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("상품 검색 v1 컨트롤러 테스트")
+class ProductSearchControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    ProductService productService;
+
+    @MockitoBean
+    JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    JwtUtil jwtUtil;
+
+    @Test
+    @DisplayName("성공: 상품 검색 v1")
+    void 상품_검색_V1_성공() throws Exception {
+        // given
+        ProductListResponse response = new ProductListResponse(
+                1L, "제주 감귤", ProductType.NORMAL,
+                15000L, 12000L, null,
+                100, ProductStatus.ON_SALE, null, LocalDateTime.now()
+        );
+
+        given(productService.normalizeKeyword("감귤")).willReturn("감귤");
+        given(productService.searchProducts(any(), any()))
+                .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/products/search")
+                        .param("keyword", "감귤"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].name").value("제주 감귤"));
+    }
+
+    @Test
+    @DisplayName("실패: 상품 검색 v1 키워드 길이 초과")
+    void 상품_검색_V1_실패_키워드길이초과() throws Exception {
+        // given
+        String longKeyword = "a".repeat(51);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/products/search")
+                        .param("keyword", longKeyword))
+                .andExpect(status().isBadRequest());
+
+        then(productService).should(never()).normalizeKeyword(any());
+        then(productService).should(never()).searchProducts(any(), any());
+    }
+}

--- a/src/test/java/com/spartafarmer/agri_commerce/product/ProductSearchV2ControllerTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/product/ProductSearchV2ControllerTest.java
@@ -1,0 +1,106 @@
+package com.spartafarmer.agri_commerce.product;
+
+import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
+import com.spartafarmer.agri_commerce.common.enums.ProductType;
+import com.spartafarmer.agri_commerce.common.enums.UserRole;
+import com.spartafarmer.agri_commerce.common.security.AuthUser;
+import com.spartafarmer.agri_commerce.domain.product.controller.ProductSearchV2Controller;
+import com.spartafarmer.agri_commerce.domain.product.dto.ProductListResponse;
+import com.spartafarmer.agri_commerce.domain.product.service.PopularSearchService;
+import com.spartafarmer.agri_commerce.domain.product.service.ProductService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("상품 검색 v2 컨트롤러 단위 테스트")
+class ProductSearchV2ControllerTest {
+
+    @Mock
+    private ProductService productService;
+
+    @Mock
+    private PopularSearchService popularSearchService;
+
+    @InjectMocks
+    private ProductSearchV2Controller productSearchV2Controller;
+
+    @Test
+    @DisplayName("성공: 비로그인 사용자는 인기검색어 집계 없이 검색한다")
+    void 상품_검색_V2_성공_비로그인사용자() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        ProductListResponse response = new ProductListResponse(
+                1L, "제주 감귤", ProductType.NORMAL,
+                15000L, 12000L, null,
+                100, ProductStatus.ON_SALE, null, LocalDateTime.now()
+        );
+
+        Page<ProductListResponse> page = new PageImpl<>(List.of(response), pageable, 1);
+
+        given(productService.normalizeKeyword("감귤")).willReturn("감귤");
+        given(productService.searchProductsWithCache("감귤", pageable)).willReturn(page);
+
+        // when
+        Page<ProductListResponse> result =
+                productSearchV2Controller.searchProductsV2("감귤", pageable, null);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("제주 감귤");
+
+        then(productService).should().normalizeKeyword("감귤");
+        then(productService).should().searchProductsWithCache("감귤", pageable);
+        then(popularSearchService).should(never()).increaseKeyword(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("성공: 로그인 사용자는 인기검색어를 집계한다")
+    void 상품_검색_V2_성공_로그인사용자면_인기검색어집계() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        ProductListResponse response = new ProductListResponse(
+                1L, "제주 감귤", ProductType.NORMAL,
+                15000L, 12000L, null,
+                100, ProductStatus.ON_SALE, null, LocalDateTime.now()
+        );
+
+        Page<ProductListResponse> page = new PageImpl<>(List.of(response), pageable, 1);
+
+        AuthUser authUser = new AuthUser(1L, "test@test.com", UserRole.USER);
+
+        given(productService.normalizeKeyword("감귤")).willReturn("감귤");
+        given(productService.searchProductsWithCache("감귤", pageable)).willReturn(page);
+
+        // when
+        Page<ProductListResponse> result =
+                productSearchV2Controller.searchProductsV2("감귤", pageable, authUser);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("제주 감귤");
+
+        then(productService).should().normalizeKeyword("감귤");
+        then(productService).should().searchProductsWithCache("감귤", pageable);
+        then(popularSearchService).should().increaseKeyword(1L, "감귤");
+    }
+}

--- a/src/test/java/com/spartafarmer/agri_commerce/product/ProductSearchV2ValidationTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/product/ProductSearchV2ValidationTest.java
@@ -1,0 +1,57 @@
+package com.spartafarmer.agri_commerce.product;
+
+import com.spartafarmer.agri_commerce.common.security.JwtUtil;
+import com.spartafarmer.agri_commerce.domain.product.controller.ProductSearchV2Controller;
+import com.spartafarmer.agri_commerce.domain.product.service.PopularSearchService;
+import com.spartafarmer.agri_commerce.domain.product.service.ProductService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ProductSearchV2Controller.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("상품 검색 v2 검증 테스트")
+class ProductSearchV2ValidationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    ProductService productService;
+
+    @MockitoBean
+    PopularSearchService popularSearchService;
+
+    @MockitoBean
+    JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    JwtUtil jwtUtil;
+
+    @Test
+    @DisplayName("실패: 상품 검색 v2 키워드 길이 초과")
+    void 상품_검색_V2_실패_키워드길이초과() throws Exception {
+        // given
+        String longKeyword = "a".repeat(51);
+
+        // when & then
+        mockMvc.perform(get("/api/v2/products/search")
+                        .param("keyword", longKeyword))
+                .andExpect(status().isBadRequest());
+
+        then(productService).should(never()).normalizeKeyword(any());
+        then(productService).should(never()).searchProductsWithCache(any(), any());
+        then(popularSearchService).should(never()).increaseKeyword(any(), any());
+    }
+}

--- a/src/test/java/com/spartafarmer/agri_commerce/product/ProductServiceTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/product/ProductServiceTest.java
@@ -1,0 +1,246 @@
+package com.spartafarmer.agri_commerce.product;
+
+import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
+import com.spartafarmer.agri_commerce.common.enums.ProductType;
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.domain.product.dto.ProductDetailResponse;
+import com.spartafarmer.agri_commerce.domain.product.dto.ProductListResponse;
+import com.spartafarmer.agri_commerce.domain.product.entity.Product;
+import com.spartafarmer.agri_commerce.domain.product.repository.ProductRepository;
+import com.spartafarmer.agri_commerce.domain.product.service.ProductService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductService productService;
+
+    @Test
+    void 상품_목록_조회_성공_전체상품() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Product normalProduct = Product.create(
+                "제주 감귤", ProductType.NORMAL,
+                15000L, 12000L, null,
+                100, ProductStatus.ON_SALE, null
+        );
+        Product specialProduct = Product.create(
+                "딸기 특가", ProductType.SPECIAL,
+                20000L, 20000L, 15000L,
+                50, ProductStatus.READY, null
+        );
+
+        Page<Product> page = new PageImpl<>(List.of(normalProduct, specialProduct), pageable, 2);
+
+        when(productRepository.findByStatusNotOrderByCreatedAtDesc(ProductStatus.HIDDEN, pageable))
+                .thenReturn(page);
+
+        // when
+        Page<ProductListResponse> result = productService.getProducts(null, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent())
+                .extracting(ProductListResponse::name)
+                .containsExactly("제주 감귤", "딸기 특가");
+
+        verify(productRepository).findByStatusNotOrderByCreatedAtDesc(ProductStatus.HIDDEN, pageable);
+        verify(productRepository, never()).findByTypeAndStatusNotOrderByCreatedAtDesc(any(), any(), any());
+    }
+
+    @Test
+    void 상품_목록_조회_성공_타입별상품() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Product specialProduct1 = Product.create(
+                "한우 특가", ProductType.SPECIAL,
+                50000L, 50000L, 30000L,
+                20, ProductStatus.ON_SALE, null
+        );
+        Product specialProduct2 = Product.create(
+                "딸기 특가", ProductType.SPECIAL,
+                20000L, 20000L, 15000L,
+                50, ProductStatus.READY, null
+        );
+
+        Page<Product> page = new PageImpl<>(List.of(specialProduct1, specialProduct2), pageable, 2);
+
+        when(productRepository.findByTypeAndStatusNotOrderByCreatedAtDesc(
+                ProductType.SPECIAL, ProductStatus.HIDDEN, pageable))
+                .thenReturn(page);
+
+        // when
+        Page<ProductListResponse> result = productService.getProducts(ProductType.SPECIAL, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent())
+                .allMatch(p -> p.type() == ProductType.SPECIAL);
+
+        verify(productRepository).findByTypeAndStatusNotOrderByCreatedAtDesc(ProductType.SPECIAL, ProductStatus.HIDDEN, pageable);
+        verify(productRepository, never()).findByStatusNotOrderByCreatedAtDesc(any(), any());
+    }
+
+    @Test
+    void 상품_상세_조회_성공() {
+        // given
+        Product product = Product.create(
+                "제주 감귤", ProductType.NORMAL,
+                15000L, 12000L, null,
+                100, ProductStatus.ON_SALE, null
+        );
+
+        when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+
+        // when
+        ProductDetailResponse result = productService.getProduct(1L);
+
+        // then
+        assertThat(result.name()).isEqualTo("제주 감귤");
+        assertThat(result.status()).isEqualTo(ProductStatus.ON_SALE);
+    }
+
+    @Test
+    void 상품_상세_조회_성공_READY상품() {
+        // given
+        Product readyProduct = Product.create(
+                "딸기 특가", ProductType.SPECIAL,
+                20000L, 20000L, 15000L,
+                50, ProductStatus.READY, null
+        );
+
+        when(productRepository.findById(1L)).thenReturn(Optional.of(readyProduct));
+
+        // when
+        ProductDetailResponse result = productService.getProduct(1L);
+
+        // then
+        assertThat(result.status()).isEqualTo(ProductStatus.READY);
+    }
+
+    @Test
+    void 상품_상세_조회_실패_HIDDEN상품() {
+        // given
+        Product hiddenProduct = Product.create(
+                "비공개 상품", ProductType.NORMAL,
+                10000L, 10000L, null,
+                10, ProductStatus.HIDDEN, null
+        );
+
+        when(productRepository.findById(1L)).thenReturn(Optional.of(hiddenProduct));
+
+        // when & then
+        assertThatThrownBy(() -> productService.getProduct(1L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PRODUCT_NOT_FOUND);
+    }
+
+    @Test
+    void 상품_상세_조회_실패_없는상품() {
+        // given
+        when(productRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productService.getProduct(1L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PRODUCT_NOT_FOUND);
+    }
+
+    @Test
+    void 상품_검색_성공() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Product product = Product.create(
+                "제주 감귤", ProductType.NORMAL,
+                15000L, 12000L, null,
+                100, ProductStatus.ON_SALE, null
+        );
+
+        Page<Product> page = new PageImpl<>(List.of(product), pageable, 1);
+
+        when(productRepository.findByNameContainingAndStatusNotOrderByCreatedAtDesc(
+                "감귤", ProductStatus.HIDDEN, pageable))
+                .thenReturn(page);
+
+        // when
+        Page<ProductListResponse> result = productService.searchProducts("감귤", pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("제주 감귤");
+    }
+
+    @Test
+    void 상품_검색_캐시조회_성공() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Product product = Product.create(
+                "제주 감귤", ProductType.NORMAL,
+                15000L, 12000L, null,
+                100, ProductStatus.ON_SALE, null
+        );
+
+        Page<Product> page = new PageImpl<>(List.of(product), pageable, 1);
+
+        when(productRepository.findByNameContainingAndStatusNotOrderByCreatedAtDesc(
+                "감귤", ProductStatus.HIDDEN, pageable))
+                .thenReturn(page);
+
+        // when
+        Page<ProductListResponse> result = productService.searchProductsWithCache("감귤", pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("제주 감귤");
+    }
+
+    @Test
+    void 검색어_정규화_성공_앞뒤공백제거() {
+        // given
+        String keyword = "   감귤   ";
+
+        // when
+        String result = productService.normalizeKeyword(keyword);
+
+        // then
+        assertThat(result).isEqualTo("감귤");
+    }
+
+    @Test
+    void 검색어_정규화_실패_공백만입력() {
+        // given
+        String keyword = "   ";
+
+        // when & then
+        assertThatThrownBy(() -> productService.normalizeKeyword(keyword))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_REQUEST);
+    }
+}

--- a/src/test/java/com/spartafarmer/agri_commerce/product/TimeSaleScheduleServiceTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/product/TimeSaleScheduleServiceTest.java
@@ -1,0 +1,83 @@
+package com.spartafarmer.agri_commerce.product;
+
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.domain.product.scheduler.TimeSaleEndJob;
+import com.spartafarmer.agri_commerce.domain.product.scheduler.TimeSaleStartJob;
+import com.spartafarmer.agri_commerce.domain.product.service.TimeSaleScheduleService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TimeSaleScheduleServiceTest {
+
+    @Mock
+    private Scheduler scheduler;
+
+    @InjectMocks
+    private TimeSaleScheduleService timeSaleScheduleService;
+
+    @Test
+    void Quartz_Job_등록_성공() throws Exception {
+        // given
+        Long productId = 999L;
+        LocalDateTime scheduleTime = LocalDateTime.now().plusSeconds(10);
+
+        when(scheduler.checkExists(JobKey.jobKey("TimeSaleStartJob-" + productId)))
+                .thenReturn(false);
+
+        // when
+        timeSaleScheduleService.scheduleJob(TimeSaleStartJob.class, productId, scheduleTime);
+
+        // then
+        verify(scheduler).checkExists(JobKey.jobKey("TimeSaleStartJob-" + productId));
+        verify(scheduler).scheduleJob(any(JobDetail.class), any(Trigger.class));
+    }
+
+    @Test
+    void Quartz_Job_중복등록_방지_성공() throws Exception {
+        // given
+        Long productId = 998L;
+        LocalDateTime scheduleTime = LocalDateTime.now().plusSeconds(10);
+
+        when(scheduler.checkExists(JobKey.jobKey("TimeSaleEndJob-" + productId)))
+                .thenReturn(true);
+
+        // when
+        timeSaleScheduleService.scheduleJob(TimeSaleEndJob.class, productId, scheduleTime);
+
+        // then
+        verify(scheduler).checkExists(JobKey.jobKey("TimeSaleEndJob-" + productId));
+        verify(scheduler, never()).scheduleJob(any(JobDetail.class), any(Trigger.class));
+    }
+
+    @Test
+    void Quartz_Job_등록_실패_스케줄러예외() throws Exception {
+        // given
+        Long productId = 997L;
+        LocalDateTime scheduleTime = LocalDateTime.now().plusSeconds(10);
+
+        when(scheduler.checkExists(JobKey.jobKey("TimeSaleStartJob-" + productId)))
+                .thenThrow(new SchedulerException("scheduler error"));
+
+        // when & then
+        assertThatThrownBy(() -> timeSaleScheduleService.scheduleJob(TimeSaleStartJob.class, productId, scheduleTime))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/test/java/com/spartafarmer/agri_commerce/product/TimeSaleServiceTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/product/TimeSaleServiceTest.java
@@ -1,0 +1,108 @@
+package com.spartafarmer.agri_commerce.product;
+
+import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
+import com.spartafarmer.agri_commerce.common.enums.ProductType;
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.domain.product.entity.Product;
+import com.spartafarmer.agri_commerce.domain.product.repository.ProductRepository;
+import com.spartafarmer.agri_commerce.domain.product.service.TimeSaleService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TimeSaleServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private TimeSaleService timeSaleService;
+
+    @Test
+    void 타임세일_시작_성공() {
+        // given
+        Product readyProduct = Product.create(
+                "딸기 특가", ProductType.SPECIAL,
+                20000L, 20000L, 15000L,
+                50, ProductStatus.READY, null
+        );
+
+        when(productRepository.findByIdWithLock(1L)).thenReturn(Optional.of(readyProduct));
+
+        // when
+        timeSaleService.startProductSale(1L);
+
+        // then
+        assertThat(readyProduct.getStatus()).isEqualTo(ProductStatus.ON_SALE);
+    }
+
+    @Test
+    void 타임세일_시작_성공_재고없음이면품절() {
+        // given
+        Product zeroStockReadyProduct = Product.create(
+                "재고없는 특가", ProductType.SPECIAL,
+                20000L, 20000L, 15000L,
+                0, ProductStatus.READY, null
+        );
+
+        when(productRepository.findByIdWithLock(1L)).thenReturn(Optional.of(zeroStockReadyProduct));
+
+        // when
+        timeSaleService.startProductSale(1L);
+
+        // then
+        assertThat(zeroStockReadyProduct.getStatus()).isEqualTo(ProductStatus.SOLD_OUT);
+    }
+
+    @Test
+    void 타임세일_시작_실패_상품없음() {
+        // given
+        when(productRepository.findByIdWithLock(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> timeSaleService.startProductSale(1L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PRODUCT_NOT_FOUND);
+    }
+
+    @Test
+    void 타임세일_종료_성공() {
+        // given
+        Product onSaleSpecialProduct = Product.create(
+                "한우 특가", ProductType.SPECIAL,
+                50000L, 50000L, 30000L,
+                20, ProductStatus.ON_SALE, null
+        );
+
+        when(productRepository.findByIdWithLock(1L)).thenReturn(Optional.of(onSaleSpecialProduct));
+
+        // when
+        timeSaleService.endProductSale(1L);
+
+        // then
+        assertThat(onSaleSpecialProduct.getStatus()).isEqualTo(ProductStatus.SALE_ENDED);
+    }
+
+    @Test
+    void 타임세일_종료_실패_상품없음() {
+        // given
+        when(productRepository.findByIdWithLock(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> timeSaleService.endProductSale(1L))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PRODUCT_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
**📌 작업 내용**
상품 도메인 교차 단위 테스트 작성


🔗 관련 이슈- close #118 


**🧩 변경 사항**
- ProductControllerTest
    * 상품 목록 조회 성공
    * 특가 상품 목록 조회 성공
    * 상품 상세 조회 성공

- ProductSearchControllerTest (v1)
    * 상품 검색 성공
    * 상품 검색 실패 (키워드 길이 초과)

- ProductSearchV2ControllerTest
    * 비로그인 사용자 검색 시 인기검색어 미집계
    * 로그인 사용자 검색 시 인기검색어 집계

- ProductSearchV2ValidationTest
    * 상품 검색 실패 (키워드 길이 초과)

- PopularSearchControllerTest
    * 인기검색어 조회 성공

- ProductServiceTest
    * 상품 목록 조회 성공 (전체)
    * 상품 목록 조회 성공 (타입별)
    * 상품 상세 조회 성공
    * 상품 상세 조회 실패 (HIDDEN 상품)
    * 상품 상세 조회 실패 (상품 없음)
    * 상품 검색 성공
    * 상품 검색 캐시 조회 성공
    * 검색어 정규화 성공 (공백 제거)
    * 검색어 정규화 실패 (공백만 입력)

- TimeSaleServiceTest
    * 타임세일 시작 성공
    * 타임세일 시작 성공 (재고 0 → 품절)
    * 타임세일 시작 실패 (상품 없음)
    * 타임세일 종료 성공
    * 타임세일 종료 실패 (상품 없음)

- TimeSaleScheduleServiceTest
    * Quartz Job 등록 성공
    * Quartz Job 중복 등록 방지
    * Quartz Job 등록 실패 (SchedulerException)


🧪 테스트
- [ ] Postman 1차 테스트 완료

- [ ] 단위 테스트 완료 (해당 시)


🔥 리뷰 요청
키워드 길이 검증(@Size)은 WebMvcTest 기반 validation 테스트로 별도 분리
