### PR TITLE
refactor: 쿠폰 도메인 버그 수정 및 코드 리팩토링(#122)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ docker-compose.override.yml
 # yml 파일
 /src/main/resources/application-local.yml
 /src/main/resources/application-prod.yml
+/src/main/resources/application-test.yml

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/entity/Coupon.java
@@ -31,7 +31,7 @@ public class Coupon extends BaseEntity {
     private int totalQuantity;
 
     // 현재 발급된 수량 (동시성 제어 대상)
-    @Column(nullable = false)
+    @Column(name = "issued_count", nullable = false)
     private int issuedQuantity;
 
     // 쿠폰 발급 시작 시각

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/entity/UserCoupon.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/entity/UserCoupon.java
@@ -23,6 +23,12 @@ import java.time.LocalDateTime;
 )
 public class UserCoupon extends BaseEntity {
 
+    // 만료일-> 발급일 포함 5일
+    private static final int EXPIRE_DAYS_AFTER_ISSUE = 4;
+    private static final int EXPIRE_HOUR = 23;
+    private static final int EXPIRE_MINUTE = 59;
+    private static final int EXPIRE_SECOND = 59;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -54,9 +60,9 @@ public class UserCoupon extends BaseEntity {
 
     // 쿠폰 발급
     public static UserCoupon issue(User user, Coupon coupon, LocalDateTime issuedAt) {
-
-        LocalDateTime expiredAt = issuedAt.toLocalDate().plusDays(4)
-                .atTime(23, 59, 59);
+        LocalDateTime expiredAt = issuedAt.toLocalDate()
+                .plusDays(EXPIRE_DAYS_AFTER_ISSUE)
+                .atTime(EXPIRE_HOUR, EXPIRE_MINUTE, EXPIRE_SECOND);
         return new UserCoupon(user, coupon, expiredAt);
     }
 

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/repository/CouponRepository.java
@@ -3,11 +3,5 @@ package com.spartafarmer.agri_commerce.domain.coupon.repository;
 import com.spartafarmer.agri_commerce.domain.coupon.entity.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
-
-    // 만료 처리 대상 쿠폰 조회 (endTime 이 지난 것)
-    List<Coupon> findAllByEndTimeBefore(LocalDateTime now);
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/repository/UserCouponRepository.java
@@ -2,8 +2,8 @@ package com.spartafarmer.agri_commerce.domain.coupon.repository;
 
 import com.spartafarmer.agri_commerce.common.enums.CouponStatus;
 import com.spartafarmer.agri_commerce.domain.coupon.entity.UserCoupon;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,18 +16,18 @@ public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
     // 중복 발급 확인
     boolean existsByUserIdAndCouponId(Long userId, Long couponId);
 
-    // 사용자 보유 쿠폰 목록 조회 (만료 임박순 - 주문 시 쿠폰 선택용)
-    List<UserCoupon> findByUserIdAndStatusOrderByExpiredAtAsc(Long userId, CouponStatus status);
-
-    // 만료 일괄 처리 대상 조회 (특정 쿠폰의 미사용 쿠폰들)
-    List<UserCoupon> findByCouponIdAndStatus(Long couponId, CouponStatus status, Pageable pageable);
-
-    // 단건 조회 (쿠폰 사용 시)
+    // 본인 소유 쿠폰 단건 조회 (OrderCreateService 에서 사용)
     Optional<UserCoupon> findByIdAndUserId(Long id, Long userId);
 
     // 사용자 보유 쿠폰 전체 조회 (만료 임박순, Coupon fetch join) -> N+1 해결(Fetch Join)
     @Query("SELECT uc FROM UserCoupon uc JOIN FETCH uc.coupon WHERE uc.user.id = :userId ORDER BY uc.expiredAt ASC")
     List<UserCoupon> findByUserIdOrderByExpiredAtAsc(@Param("userId") Long userId);
 
-    List<UserCoupon> findByStatusAndExpiredAtBefore(CouponStatus couponStatus, LocalDateTime now);  //
+    // 만료 처리 벌크 UPDATE -> fromStatus 상태 + 만료시각 지난 쿠폰들을 한 번에 toStatus로 변경
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE UserCoupon uc SET uc.status = :toStatus " +
+            "WHERE uc.status = :fromStatus AND uc.expiredAt < :now")
+    int bulkExpire(@Param("fromStatus") CouponStatus fromStatus,
+                   @Param("toStatus") CouponStatus toStatus,
+                   @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/scheduler/CouponCreateScheduler.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/scheduler/CouponCreateScheduler.java
@@ -15,18 +15,30 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class CouponCreateScheduler {
 
+    // 주간 쿠폰 정책
+    private static final String WEEKLY_COUPON_NAME = "주간 선착순 할인 쿠폰";
+    private static final Long WEEKLY_COUPON_DISCOUNT_AMOUNT = 5000L;
+    private static final int WEEKLY_COUPON_TOTAL_QUANTITY = 50;
+
+    // 발급 가능 시간 - 당일 09:00 ~ 23:59:59
+    private static final int ISSUE_START_HOUR = 9;
+    private static final int ISSUE_START_MINUTE = 0;
+    private static final int ISSUE_END_HOUR = 23;
+    private static final int ISSUE_END_MINUTE = 59;
+    private static final int ISSUE_END_SECOND = 59;
+
     private final CouponRepository couponRepository;
 
-    @Scheduled(cron = "0 0 9 * * MON")  // 매주 월요일 오전 9시에 실행
+    @Scheduled(cron = "0 0 9 * * MON")
     public void createWeeklyCoupon() {
         LocalDate today = LocalDate.now();
-        LocalDateTime startTime = today.atTime(9, 0);   // 발급 가능 시각 09시
-        LocalDateTime endTime = today.atTime(23, 59, 59);   // 발급 종료 시각 23:59:59
+        LocalDateTime startTime = today.atTime(ISSUE_START_HOUR, ISSUE_START_MINUTE);
+        LocalDateTime endTime = today.atTime(ISSUE_END_HOUR, ISSUE_END_MINUTE, ISSUE_END_SECOND);
 
         Coupon coupon = Coupon.create(
-                "주간 선착순 할인 쿠폰",
-                5000L,  // 할인 금액 5,000원
-                50,                   // 수량 50개
+                WEEKLY_COUPON_NAME,
+                WEEKLY_COUPON_DISCOUNT_AMOUNT,
+                WEEKLY_COUPON_TOTAL_QUANTITY,
                 startTime,
                 endTime
         );

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/scheduler/CouponExpireScheduler.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/scheduler/CouponExpireScheduler.java
@@ -22,13 +22,12 @@ public class CouponExpireScheduler {
     @Scheduled(cron = "0 0 0 * * SAT")  // 매주 토요일 자정에 실행
     @Transactional
     public void expireCoupons() {
-        List<UserCoupon> expiredCoupons = userCouponRepository
-                .findByStatusAndExpiredAtBefore(CouponStatus.AVAILABLE, LocalDateTime.now());
+        int updated = userCouponRepository.bulkExpire(
+                CouponStatus.AVAILABLE,
+                CouponStatus.EXPIRED,
+                LocalDateTime.now()
+        );
 
-        for (UserCoupon userCoupon : expiredCoupons) {
-            userCoupon.expire();
-        }
-
-        log.info("만료 쿠폰 처리 완료 - {}건", expiredCoupons.size());
+        log.info("만료 쿠폰 처리 완료 - {}건", updated);
     }
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponIssueService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponIssueService.java
@@ -43,10 +43,11 @@ public class CouponIssueService {
             throw new CustomException(ErrorCode.COUPON_SOLD_OUT);
         }
 
-        // 모든 검증 통과 후 상태 변경 시작
         // UserCoupon 생성 시 연관관계만 필요하므로 프록시로 조회 (SELECT 쿼리 생략)
-        User user = userRepository.getReferenceById(userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
+        // 모든 검증 통과 후 상태 변경
         coupon.increaseIssuedQuantity();
 
         UserCoupon userCoupon = UserCoupon.issue(user, coupon, LocalDateTime.now());

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponIssueService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponIssueService.java
@@ -43,10 +43,11 @@ public class CouponIssueService {
             throw new CustomException(ErrorCode.COUPON_SOLD_OUT);
         }
 
-        coupon.increaseIssuedQuantity();
+        // 모든 검증 통과 후 상태 변경 시작
+        // UserCoupon 생성 시 연관관계만 필요하므로 프록시로 조회 (SELECT 쿼리 생략)
+        User user = userRepository.getReferenceById(userId);
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        coupon.increaseIssuedQuantity();
 
         UserCoupon userCoupon = UserCoupon.issue(user, coupon, LocalDateTime.now());
         userCouponRepository.save(userCoupon);

--- a/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponConcurrencyTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponConcurrencyTest.java
@@ -1,6 +1,8 @@
 package com.spartafarmer.agri_commerce.coupon;
 
 import com.spartafarmer.agri_commerce.common.enums.UserRole;
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
 import com.spartafarmer.agri_commerce.domain.coupon.entity.Coupon;
 import com.spartafarmer.agri_commerce.domain.coupon.repository.CouponRepository;
 import com.spartafarmer.agri_commerce.domain.coupon.repository.UserCouponRepository;
@@ -16,6 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -25,6 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("integration")
+@Tag("concurrency")
 @SpringBootTest
 @ActiveProfiles("test")
 public class CouponConcurrencyTest {
@@ -60,8 +64,10 @@ public class CouponConcurrencyTest {
         couponRepository.save(coupon);
         this.couponId = coupon.getId();
 
+        // 150명 더미 유저 일괄 저장 (save() 150회 -> saveAll() 1회로 개선)
+        List<User> users = new ArrayList<>();
         for (int i = 1; i <= 150; i++) {
-            userRepository.save(User.create(
+            users.add(User.create(
                     "user" + i + "@test.com",
                     "password1",
                     "테스터" + i,
@@ -70,6 +76,7 @@ public class CouponConcurrencyTest {
                     UserRole.USER
             ));
         }
+        userRepository.saveAll(users);
 
         this.userIds = userRepository.findAll().stream()
                 .map(User::getId)
@@ -80,8 +87,9 @@ public class CouponConcurrencyTest {
     @DisplayName("100개 수량 쿠폰에 150명이 동시 발급 요청 시 정확히 100개만 발급된다")
     void concurrencyIssueTest() throws InterruptedException {
         int threadCount = 150;
-        ExecutorService executorService = Executors.newFixedThreadPool(32);
-        CountDownLatch latch = new CountDownLatch(threadCount);
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);              // 시작 신호용
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);     // 완료 대기용
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger failCount = new AtomicInteger(0);
 
@@ -90,29 +98,40 @@ public class CouponConcurrencyTest {
 
             executorService.submit(() -> {
                 try {
-                    // 최대 50번 재시도, 100ms 간격
-                    for (int retry = 0; retry < 50; retry++) {
+                    startLatch.await();  // 모든 스레드가 여기서 대기
+
+                    boolean done = false;
+                    for (int retry = 0; retry < 100; retry++) {
                         try {
                             couponService.issueCoupon(couponId, userId);
                             successCount.incrementAndGet();
+                            done = true;
                             break;
-                        } catch (Exception e) {
-                            if (!e.getMessage().contains("요청이 많아")) {
+                        } catch (CustomException e) {
+                            // 락 획득 실패만 재시도, 그 외 비즈니스 예외는 즉시 실패 처리
+                            // (기존: 예외 메시지 문자열 매칭 -> ErrorCode 비교로 변경)
+                            if (e.getErrorCode() != ErrorCode.LOCK_ACQUIRE_FAILED) {
                                 failCount.incrementAndGet();
+                                done = true;
                                 break;
                             }
-                            Thread.sleep(100);
+                            Thread.sleep(50);
                         }
+                    }
+                    if (!done) {
+                        failCount.incrementAndGet();
                     }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
+                    failCount.incrementAndGet();
                 } finally {
-                    latch.countDown();
+                    doneLatch.countDown();
                 }
             });
         }
 
-        latch.await();
+        startLatch.countDown();  // 150개 스레드 동시 출발
+        doneLatch.await();       // 전부 끝날 때까지 대기
         executorService.shutdown();
 
         Coupon result = couponRepository.findById(couponId).orElseThrow();

--- a/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponIssueServiceTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponIssueServiceTest.java
@@ -52,7 +52,7 @@ class CouponIssueServiceTest {
         given(coupon.isAvailableNow(any())).willReturn(true);
         given(userCouponRepository.existsByUserIdAndCouponId(userId, couponId)).willReturn(false);
         given(coupon.hasRemaining()).willReturn(true);
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userRepository.getReferenceById(userId)).willReturn(user);
 
         given(userCouponRepository.save(any())).willReturn(userCoupon);
 
@@ -126,23 +126,4 @@ class CouponIssueServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COUPON_SOLD_OUT);
     }
 
-    @Test
-    @DisplayName("실패: 존재하지 않는 유저 ID로 발급 요청 시 예외를 던진다.")
-    void issueCoupon_실패_유저_없음() {
-        Coupon coupon = mock(Coupon.class);
-
-        given(couponRepository.findById(any()))
-                .willReturn(Optional.of(coupon));
-        given(coupon.isAvailableNow(any())).willReturn(true);
-        given(userCouponRepository.existsByUserIdAndCouponId(any(), any()))
-                .willReturn(false);
-        given(coupon.hasRemaining()).willReturn(true);
-        given(userRepository.findById(any()))
-                .willReturn(Optional.empty());
-
-        assertThatThrownBy(() ->
-                couponIssueService.issueCoupon(1L, 1L))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
-    }
 }

--- a/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponIssueServiceTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponIssueServiceTest.java
@@ -52,7 +52,7 @@ class CouponIssueServiceTest {
         given(coupon.isAvailableNow(any())).willReturn(true);
         given(userCouponRepository.existsByUserIdAndCouponId(userId, couponId)).willReturn(false);
         given(coupon.hasRemaining()).willReturn(true);
-        given(userRepository.getReferenceById(userId)).willReturn(user);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         given(userCouponRepository.save(any())).willReturn(userCoupon);
 
@@ -124,6 +124,27 @@ class CouponIssueServiceTest {
                 couponIssueService.issueCoupon(1L, 1L))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COUPON_SOLD_OUT);
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 유저 ID로 발급 요청 시 예외를 던진다.")
+    void issueCoupon_실패_유저_없음() {
+        // given
+        Long couponId = 1L;
+        Long userId = 999L;
+
+        Coupon coupon = mock(Coupon.class);
+
+        given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
+        given(coupon.isAvailableNow(any())).willReturn(true);
+        given(userCouponRepository.existsByUserIdAndCouponId(userId, couponId)).willReturn(false);
+        given(coupon.hasRemaining()).willReturn(true);
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> couponIssueService.issueCoupon(couponId, userId))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
     }
 
 }


### PR DESCRIPTION
📌 작업 내용- 어떤 작업인지 한 줄로 설명
쿠폰 도메인 코드 리뷰 기반 버그 수정 및 리팩토링

🔗 관련 이슈- close #이슈번호
close #122

🧩 변경 사항- 주요 변경 내용- 핵심 로직 / 구현 포인트
**버그 수정**
- `CouponIssueService` 발급 조건 검증 완료 후 상태 변경(`increaseIssuedQuantity`)하도록 순서 정리
- `Coupon.issuedQuantity` 필드에 `@Column(name = "issued_count")` 추가 (ERD 컬럼명 매핑 불일치 해결)

**성능 개선**
- `CouponIssueService`: `findById` → `getReferenceById`로 변경 (불필요한 SELECT 제거)
- `CouponExpireScheduler`: for-loop UPDATE → `@Modifying` 벌크 UPDATE 쿼리로 전환

**코드 정리**
- 매직 넘버 상수화 (`UserCoupon` 만료일 계산, `CouponCreateScheduler` 발급 시각)
- 미사용 Repository 메서드 제거 (`findByUserIdAndStatusOrderByExpiredAtAsc`, `findByCouponIdAndStatus`, `findByStatusAndExpiredAtBefore`, `findAllByEndTimeBefore`)
- `CouponIssueResponse` 포맷 정리

**테스트**
- `CouponConcurrencyTest`: `@Tag("concurrency")` 추가, 예외 매칭을 `ErrorCode` 비교로 변경, 유저 생성 `saveAll()` 적용
- `CouponIssueServiceTest`: `getReferenceById` 변경에 따른 mock 수정 및 "유저 없음" 케이스 제거

🧪 테스트
- [x] Postman 1차 테스트 완료

- [x] 단위 테스트 완료 (해당 시)


🔥 리뷰 요청 (있으면 작성)- 중점적으로 봐줬으면 하는 부분 1개
