### PR TITLE
refactor: 쿠폰 발급 동시성 보완 - DB 조건부 UPDATE 적용(#187)

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/repository/CouponRepository.java
@@ -2,6 +2,16 @@ package com.spartafarmer.agri_commerce.domain.coupon.repository;
 
 import com.spartafarmer.agri_commerce.domain.coupon.entity.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+    // 조건부 UPDATE - 수량 여유가 있을 때만 issuedQuantity 증가
+    // affected rows = 1: 성공, 0: 수량 소진
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Coupon c SET c.issuedQuantity = c.issuedQuantity + 1 " +
+            "WHERE c.id = :couponId AND c.issuedQuantity < c.totalQuantity")
+    int increaseIssuedQuantityIfAvailable(@Param("couponId") Long couponId);
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponIssueService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponIssueService.java
@@ -39,7 +39,10 @@ public class CouponIssueService {
             throw new CustomException(ErrorCode.COUPON_ALREADY_ISSUED);
         }
 
-        if (!coupon.hasRemaining()) {
+        // 조건부 UPDATE로 수량 증가 (DB 레벨 안전장치)
+        // 락 TTL 만료 등 예외 상황에서도 수량 초과 방지
+        int updated = couponRepository.increaseIssuedQuantityIfAvailable(couponId);
+        if (updated == 0) {
             throw new CustomException(ErrorCode.COUPON_SOLD_OUT);
         }
 

--- a/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponIssueServiceTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponIssueServiceTest.java
@@ -51,7 +51,7 @@ class CouponIssueServiceTest {
         given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
         given(coupon.isAvailableNow(any())).willReturn(true);
         given(userCouponRepository.existsByUserIdAndCouponId(userId, couponId)).willReturn(false);
-        given(coupon.hasRemaining()).willReturn(true);
+        given(couponRepository.increaseIssuedQuantityIfAvailable(couponId)).willReturn(1);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
         given(userCouponRepository.save(any())).willReturn(userCoupon);
@@ -61,7 +61,7 @@ class CouponIssueServiceTest {
 
         // then
         assertThat(response).isNotNull();
-        verify(coupon).increaseIssuedQuantity();
+        verify(couponRepository).increaseIssuedQuantityIfAvailable(couponId);
     }
 
     @Test
@@ -118,7 +118,7 @@ class CouponIssueServiceTest {
         given(coupon.isAvailableNow(any())).willReturn(true);
         given(userCouponRepository.existsByUserIdAndCouponId(any(), any()))
                 .willReturn(false);
-        given(coupon.hasRemaining()).willReturn(false);
+        given(couponRepository.increaseIssuedQuantityIfAvailable(any())).willReturn(0);
 
         assertThatThrownBy(() ->
                 couponIssueService.issueCoupon(1L, 1L))
@@ -138,7 +138,7 @@ class CouponIssueServiceTest {
         given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
         given(coupon.isAvailableNow(any())).willReturn(true);
         given(userCouponRepository.existsByUserIdAndCouponId(userId, couponId)).willReturn(false);
-        given(coupon.hasRemaining()).willReturn(true);
+        given(couponRepository.increaseIssuedQuantityIfAvailable(couponId)).willReturn(1);
         given(userRepository.findById(userId)).willReturn(Optional.empty());
 
         // when & then


### PR DESCRIPTION
📌 작업 내용- 어떤 작업인지 한 줄로 설명
- 쿠폰 발급 시 락 TTL 만료 등 예외 상황에서 수량 초과를 방지하기 위해 동시성 로직 보완

🔗 관련 이슈- close #이슈번호
- close #187 

🧩 변경 사항- 주요 변경 내용- 핵심 로직 / 구현 포인트
- `CouponRepository`에 조건부 UPDATE 쿼리 `increaseIssuedQuantityIfAvailable` 추가
  - `WHERE issued_count < total_count` 조건으로 수량 검증과 증가를 DB에서 원자적으로 처리
- `CouponIssueService`에서 기존 `hasRemaining()` 검증 + `increaseIssuedQuantity()` 두 단계를 위 쿼리 한 번 호출로 통합
  - affected rows = 0이면 `COUPON_SOLD_OUT` 예외 처리
- 기존 분산락은 그대로 유지 (성능 최적화 목적), DB 조건부 UPDATE를 최후 안전장치로 추가

🧪 테스트
- [x] 단위 테스트 완료 (`CouponIssueServiceTest` 수정)
- [x] 동시성 테스트 통과 (`CouponConcurrencyTest`)

🔥 리뷰 요청 (있으면 작성)- 중점적으로 봐줬으면 하는 부분 1개
- 분산락(Redis) + DB 조건부 UPDATE 이중 방어 구조가 적절한지 봐주세요