### PR TITLE
refactor: 쿠폰 생성 검증 메시지 명확화(#188)

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/request/CouponCreateRequest.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/dto/request/CouponCreateRequest.java
@@ -7,9 +7,21 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 public record CouponCreateRequest(
-        @NotBlank String name,
-        @NotNull @Min(1) Long discountAmount,
-        @NotNull @Min(1) Integer totalQuantity,
-        @NotNull LocalDateTime startTime,
-        @NotNull LocalDateTime endTime
+
+        @NotBlank(message = "쿠폰 이름은 필수입니다.")
+        String name,
+
+        @NotNull(message = "할인 금액은 필수입니다.")
+        @Min(value = 1, message = "할인 금액은 1원 이상이어야 합니다.")
+        Long discountAmount,
+
+        @NotNull(message = "발급 수량은 필수입니다.")
+        @Min(value = 1, message = "발급 수량은 1개 이상이어야 합니다.")
+        Integer totalQuantity,
+
+        @NotNull(message = "시작 시각은 필수입니다.")
+        LocalDateTime startTime,
+
+        @NotNull(message = "종료 시각은 필수입니다.")
+        LocalDateTime endTime
 ) {}

--- a/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponIntegrationTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponIntegrationTest.java
@@ -159,6 +159,7 @@ public class CouponIntegrationTest {
 
     @Test
     void 쿠폰_생성_실패_할인금액_음수() throws Exception {
+        // given
         CouponCreateRequest request = new CouponCreateRequest(
                 "음수 쿠폰",
                 -1000L,
@@ -167,11 +168,10 @@ public class CouponIntegrationTest {
                 LocalDateTime.now().plusDays(1)
         );
 
-        ResultActions result = mockMvc.perform(post("/api/coupons")
-                .header("Authorization", bearerToken(adminToken))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)));
+        // when
+        ResultActions result = 쿠폰생성요청(request);
 
+        // then
         result.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("할인 금액은 1원 이상이어야 합니다."));
@@ -179,6 +179,7 @@ public class CouponIntegrationTest {
 
     @Test
     void 쿠폰_생성_실패_할인금액_0() throws Exception {
+        // given
         CouponCreateRequest request = new CouponCreateRequest(
                 "0원 쿠폰",
                 0L,
@@ -187,11 +188,10 @@ public class CouponIntegrationTest {
                 LocalDateTime.now().plusDays(1)
         );
 
-        ResultActions result = mockMvc.perform(post("/api/coupons")
-                .header("Authorization", bearerToken(adminToken))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)));
+        // when
+        ResultActions result = 쿠폰생성요청(request);
 
+        // then
         result.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("할인 금액은 1원 이상이어야 합니다."));
@@ -425,6 +425,13 @@ public class CouponIntegrationTest {
     private ResultActions 쿠폰발급요청(Long couponId, String token) throws Exception {
         return mockMvc.perform(post("/api/coupons/{couponId}/issue", couponId)
                 .header("Authorization", bearerToken(token)));
+    }
+
+    private ResultActions 쿠폰생성요청(CouponCreateRequest request) throws Exception {
+        return mockMvc.perform(post("/api/coupons")
+                .header("Authorization", bearerToken(adminToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
     }
 
     private String bearerToken(String token) {

--- a/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponIntegrationTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponIntegrationTest.java
@@ -158,6 +158,46 @@ public class CouponIntegrationTest {
     }
 
     @Test
+    void 쿠폰_생성_실패_할인금액_음수() throws Exception {
+        CouponCreateRequest request = new CouponCreateRequest(
+                "음수 쿠폰",
+                -1000L,
+                100,
+                LocalDateTime.now().plusHours(1),
+                LocalDateTime.now().plusDays(1)
+        );
+
+        ResultActions result = mockMvc.perform(post("/api/coupons")
+                .header("Authorization", bearerToken(adminToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("할인 금액은 1원 이상이어야 합니다."));
+    }
+
+    @Test
+    void 쿠폰_생성_실패_할인금액_0() throws Exception {
+        CouponCreateRequest request = new CouponCreateRequest(
+                "0원 쿠폰",
+                0L,
+                100,
+                LocalDateTime.now().plusHours(1),
+                LocalDateTime.now().plusDays(1)
+        );
+
+        ResultActions result = mockMvc.perform(post("/api/coupons")
+                .header("Authorization", bearerToken(adminToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("할인 금액은 1원 이상이어야 합니다."));
+    }
+
+    @Test
     void 쿠폰_생성_실패_일반유저_권한없음() throws Exception {
         // given
         CouponCreateRequest request = new CouponCreateRequest(


### PR DESCRIPTION
📌 작업 내용- 어떤 작업인지 한 줄로 설명
 쿠폰 생성 검증 메시지 명확화

🔗 관련 이슈- close #이슈번호
- close #188 

🧩 변경 사항- 주요 변경 내용- 핵심 로직 / 구현 포인트
- 검증 자체는 기존 @Min(1)로 동작 완료
- 응답 메시지가 어떤 필드의 문제인지 모호함을 명확한 메시지로 개선 

🧪 테스트
- [x] Postman 1차 테스트 완료

- [x] 단위 테스트 완료 (해당 시)


🔥 리뷰 요청 (있으면 작성)- 중점적으로 봐줬으면 하는 부분 1개
