### PR TITLE
refactor: 쿠폰 발급 사용자 조회 프록시 변경 및 미사용 메서드 정리(#195)

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/entity/Coupon.java
@@ -63,11 +63,6 @@ public class Coupon extends BaseEntity {
         this.issuedQuantity++;
     }
 
-    // 잔여 수량 확인
-    public boolean hasRemaining() {
-        return this.issuedQuantity < this.totalQuantity;
-    }
-
     // 발급 가능 시간 확인
     public boolean isAvailableNow(LocalDateTime now) {
         return !now.isBefore(startTime) && !now.isAfter(endTime);

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponIssueService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/coupon/service/CouponIssueService.java
@@ -47,11 +47,8 @@ public class CouponIssueService {
         }
 
         // UserCoupon 생성 시 연관관계만 필요하므로 프록시로 조회 (SELECT 쿼리 생략)
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        // 모든 검증 통과 후 상태 변경
-        coupon.increaseIssuedQuantity();
+        // JWT 인증을 통과한 userId라 존재 검증 불필요
+        User user = userRepository.getReferenceById(userId);
 
         UserCoupon userCoupon = UserCoupon.issue(user, coupon, LocalDateTime.now());
         userCouponRepository.save(userCoupon);

--- a/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponIssueServiceTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/coupon/CouponIssueServiceTest.java
@@ -52,7 +52,7 @@ class CouponIssueServiceTest {
         given(coupon.isAvailableNow(any())).willReturn(true);
         given(userCouponRepository.existsByUserIdAndCouponId(userId, couponId)).willReturn(false);
         given(couponRepository.increaseIssuedQuantityIfAvailable(couponId)).willReturn(1);
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userRepository.getReferenceById(userId)).willReturn(user);
 
         given(userCouponRepository.save(any())).willReturn(userCoupon);
 
@@ -124,27 +124,6 @@ class CouponIssueServiceTest {
                 couponIssueService.issueCoupon(1L, 1L))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COUPON_SOLD_OUT);
-    }
-
-    @Test
-    @DisplayName("실패: 존재하지 않는 유저 ID로 발급 요청 시 예외를 던진다.")
-    void issueCoupon_실패_유저_없음() {
-        // given
-        Long couponId = 1L;
-        Long userId = 999L;
-
-        Coupon coupon = mock(Coupon.class);
-
-        given(couponRepository.findById(couponId)).willReturn(Optional.of(coupon));
-        given(coupon.isAvailableNow(any())).willReturn(true);
-        given(userCouponRepository.existsByUserIdAndCouponId(userId, couponId)).willReturn(false);
-        given(couponRepository.increaseIssuedQuantityIfAvailable(couponId)).willReturn(1);
-        given(userRepository.findById(userId)).willReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> couponIssueService.issueCoupon(couponId, userId))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
     }
 
 }


### PR DESCRIPTION
📌 작업 내용
- 쿠폰 발급 동시성 보완(#187) 후속 정리 - 사용자 조회 프록시 변경 및 미사용 메서드 삭제

🔗 관련 이슈
- close #195 

🧩 변경 사항
- `CouponIssueService` 사용자 조회를 `findById` → `getReferenceById`로 변경
-  JWT 인증을 통과한 userId라 존재 검증 불필요 → 불필요한 SELECT 쿼리 제거
- `CouponIssueService`에서 `coupon.increaseIssuedQuantity()` 호출 제거
- DB 조건부 UPDATE
- `Coupon.hasRemaining()` 메서드 삭제

🧪 테스트
- [x] 단위 테스트 완료 (`CouponIssueServiceTest`)
- [x] 통합 테스트 통과 (`CouponIntegrationTest`)
- [x] 동시성 테스트 통과 (`CouponConcurrencyTest`)
- [x] 더미데이터 정상 생성 확인

🔥 리뷰 요청 (있으면 작성)- 중점적으로 봐줬으면 하는 부분 1개
