### PR TITLE
Refactor: 장바구니 조회 성능 개선 및 주문 재고 차감 동시성 보강

### DIFF
--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/repository/CartRepository.java
@@ -12,6 +12,12 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
 
     Optional<Cart> findByUser(User user);
 
-    @Query("SELECT c FROM Cart c JOIN FETCH c.cartItems ci JOIN FETCH ci.product WHERE c.user = :user")
+    @Query("""
+    SELECT DISTINCT c
+    FROM Cart c
+    LEFT JOIN FETCH c.cartItems ci
+    LEFT JOIN FETCH ci.product
+    WHERE c.user = :user
+""")
     Optional<Cart> findByUserWithItems(@Param("user") User user);
 }

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/cart/service/CartService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/cart/service/CartService.java
@@ -85,7 +85,7 @@ public class CartService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        Cart cart = cartRepository.findByUser(user)
+        Cart cart = cartRepository.findByUserWithItems(user)
                 .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
         List<CartItemResponse> items = cart.getCartItems().stream()
                 .map(item -> new CartItemResponse(

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/order/service/OrderCreateService.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/order/service/OrderCreateService.java
@@ -1,5 +1,6 @@
 package com.spartafarmer.agri_commerce.domain.order.service;
 
+import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
 import com.spartafarmer.agri_commerce.common.exception.CustomException;
 import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
 import com.spartafarmer.agri_commerce.domain.cart.entity.Cart;
@@ -13,6 +14,7 @@ import com.spartafarmer.agri_commerce.domain.order.entity.Order;
 import com.spartafarmer.agri_commerce.domain.order.entity.OrderItem;
 import com.spartafarmer.agri_commerce.domain.order.repository.OrderRepository;
 import com.spartafarmer.agri_commerce.domain.product.entity.Product;
+import com.spartafarmer.agri_commerce.domain.product.repository.ProductRepository;
 import com.spartafarmer.agri_commerce.domain.user.entity.User;
 import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,7 @@ public class OrderCreateService {
     private final CartRepository cartRepository;
     private final OrderRepository orderRepository;
     private final UserCouponRepository userCouponRepository;
+    private final ProductRepository productRepository;
 
     /**
      * 주문 생성 전체 흐름
@@ -76,7 +79,7 @@ public class OrderCreateService {
 
     // 장바구니 조회
     private Cart getCart(User user) {
-        return cartRepository.findByUser(user)
+        return cartRepository.findByUserWithItems(user)
                 .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
     }
 
@@ -140,12 +143,21 @@ public class OrderCreateService {
         return finalPrice;
     }
 
-    // 주문 상품 생성 및 재고 차감
+    // 주문 생성 및 DB 원자적 재고 차감
     private void createOrderItemsAndDecreaseStock(Order order, List<CartItem> cartItems) {
         for (CartItem item : cartItems) {
                 Product product = item.getProduct();
                 // 재고 차감
-                product.decreaseStock(item.getQuantity());
+            int updatedCount = productRepository.decreaseStockAtomic(
+                    product.getId(),
+                    item.getQuantity(),
+                    ProductStatus.ON_SALE,
+                    ProductStatus.SOLD_OUT
+            );
+
+            if (updatedCount == 0) {
+                throw new CustomException(ErrorCode.OUT_OF_STOCK);
+            }
                 // 주문 상품 생성
                 OrderItem.create(
                         order,

--- a/src/main/java/com/spartafarmer/agri_commerce/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/spartafarmer/agri_commerce/domain/product/repository/ProductRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import java.util.Optional;
@@ -34,5 +35,24 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("select p from Product p where p.id = :productId")
     Optional<Product> findByIdWithLock(@Param("productId") Long productId);
 
-
+    // 주문 생성 시 재고를 DB 레벨에서 원자적으로 차감
+    @Modifying(flushAutomatically = true)
+    @Query("""
+    update Product p
+    set p.stock = p.stock - :quantity,
+        p.status = case
+            when p.stock - :quantity = 0 then :soldOutStatus
+            else p.status
+        end,
+        p.version = p.version + 1
+    where p.id = :productId
+      and p.status = :onSaleStatus
+      and p.stock >= :quantity
+""")
+    int decreaseStockAtomic(
+            @Param("productId") Long productId,
+            @Param("quantity") int quantity,
+            @Param("onSaleStatus") ProductStatus onSaleStatus,
+            @Param("soldOutStatus") ProductStatus soldOutStatus
+    );
 }

--- a/src/test/java/com/spartafarmer/agri_commerce/cart/CartControllerTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/cart/CartControllerTest.java
@@ -1,0 +1,225 @@
+package com.spartafarmer.agri_commerce.cart;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
+import com.spartafarmer.agri_commerce.common.enums.UserRole;
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.common.security.AuthUser;
+import com.spartafarmer.agri_commerce.common.security.JwtUtil;
+import com.spartafarmer.agri_commerce.domain.cart.controller.CartController;
+import com.spartafarmer.agri_commerce.domain.cart.dto.CartAddRequest;
+import com.spartafarmer.agri_commerce.domain.cart.dto.CartAddResponse;
+import com.spartafarmer.agri_commerce.domain.cart.dto.CartItemResponse;
+import com.spartafarmer.agri_commerce.domain.cart.dto.CartResponse;
+import com.spartafarmer.agri_commerce.domain.cart.dto.CartUpdateRequest;
+import com.spartafarmer.agri_commerce.domain.cart.dto.CartUpdateResponse;
+import com.spartafarmer.agri_commerce.domain.cart.service.CartService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CartController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class CartControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    CartService cartService;
+
+    @MockitoBean
+    JwtUtil jwtUtil;
+
+    @MockitoBean
+    JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @BeforeEach
+    void setUp() {
+        AuthUser authUser = new AuthUser(1L, "test@test.com", UserRole.USER);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(authUser, null, authUser.getAuthorities())
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void 장바구니_상품추가_성공() throws Exception {
+        CartAddResponse response = new CartAddResponse(
+                1L,
+                10L,
+                "사과",
+                2500L,
+                2
+        );
+
+        given(cartService.addCart(eq(1L), any(CartAddRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/api/carts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CartAddRequest(10L, 2))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.message").value("장바구니 담기 성공"))
+                .andExpect(jsonPath("$.data.cartItemId").value(1))
+                .andExpect(jsonPath("$.data.productId").value(10))
+                .andExpect(jsonPath("$.data.productName").value("사과"))
+                .andExpect(jsonPath("$.data.price").value(2500))
+                .andExpect(jsonPath("$.data.quantity").value(2))
+                .andExpect(jsonPath("$.data.totalPrice").value(5000));
+    }
+
+    @Test
+    void 장바구니_상품추가_실패_상품없음() throws Exception {
+        given(cartService.addCart(eq(1L), any(CartAddRequest.class)))
+                .willThrow(new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        mockMvc.perform(post("/api/carts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CartAddRequest(999L, 1))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("상품을 찾을 수 없습니다."));
+    }
+
+    @Test
+    void 장바구니_조회_성공() throws Exception {
+        CartItemResponse item = new CartItemResponse(
+                1L,
+                10L,
+                "감자",
+                3000L,
+                3,
+                ProductStatus.ON_SALE
+        );
+
+        CartResponse response = new CartResponse(
+                List.of(item),
+                9000L,
+                20000L,
+                false
+        );
+
+        given(cartService.getCart(1L)).willReturn(response);
+
+        mockMvc.perform(get("/api/carts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("장바구니 조회 성공"))
+                .andExpect(jsonPath("$.data.cartItems.length()").value(1))
+                .andExpect(jsonPath("$.data.cartItems[0].cartItemId").value(1))
+                .andExpect(jsonPath("$.data.cartItems[0].productId").value(10))
+                .andExpect(jsonPath("$.data.cartItems[0].productName").value("감자"))
+                .andExpect(jsonPath("$.data.cartItems[0].price").value(3000))
+                .andExpect(jsonPath("$.data.cartItems[0].quantity").value(3))
+                .andExpect(jsonPath("$.data.cartItems[0].totalPrice").value(9000))
+                .andExpect(jsonPath("$.data.cartItems[0].productStatus").value("ON_SALE"))
+                .andExpect(jsonPath("$.data.totalPrice").value(9000))
+                .andExpect(jsonPath("$.data.minOrderAmount").value(20000))
+                .andExpect(jsonPath("$.data.isMinOrderAmountMet").value(false));
+    }
+
+    @Test
+    void 장바구니_조회_실패_장바구니없음() throws Exception {
+        given(cartService.getCart(1L))
+                .willThrow(new CustomException(ErrorCode.CART_NOT_FOUND));
+
+        mockMvc.perform(get("/api/carts"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("장바구니를 찾을 수 없습니다."));
+    }
+
+    @Test
+    void 장바구니_수량변경_성공() throws Exception {
+        CartUpdateResponse response = new CartUpdateResponse(
+                1L,
+                10L,
+                "고구마",
+                5000L,
+                4
+        );
+
+        given(cartService.updateQuantity(eq(1L), any(CartUpdateRequest.class), eq(1L)))
+                .willReturn(response);
+
+        mockMvc.perform(patch("/api/carts/{cartItemId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CartUpdateRequest(4))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("장바구니 수량 변경 성공"))
+                .andExpect(jsonPath("$.data.cartItemId").value(1))
+                .andExpect(jsonPath("$.data.productId").value(10))
+                .andExpect(jsonPath("$.data.productName").value("고구마"))
+                .andExpect(jsonPath("$.data.price").value(5000))
+                .andExpect(jsonPath("$.data.quantity").value(4))
+                .andExpect(jsonPath("$.data.totalPrice").value(20000));
+    }
+
+    @Test
+    void 장바구니_수량변경_실패_재고부족() throws Exception {
+        given(cartService.updateQuantity(eq(1L), any(CartUpdateRequest.class), eq(1L)))
+                .willThrow(new CustomException(ErrorCode.OUT_OF_STOCK));
+
+        mockMvc.perform(patch("/api/carts/{cartItemId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CartUpdateRequest(999))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.message").value("재고가 부족합니다."));
+    }
+
+    @Test
+    void 장바구니_상품삭제_성공() throws Exception {
+        mockMvc.perform(delete("/api/carts/items/{cartItemId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("장바구니 상품 삭제 성공"))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @Test
+    void 장바구니_상품삭제_실패_상품없음_또는_소유자아님() throws Exception {
+        doThrow(new CustomException(ErrorCode.CART_ITEM_NOT_FOUND))
+                .when(cartService)
+                .deleteCartItem(anyLong(), anyLong());
+
+        mockMvc.perform(delete("/api/carts/items/{cartItemId}", 999L))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("장바구니 상품을 찾을 수 없습니다."));
+    }
+}

--- a/src/test/java/com/spartafarmer/agri_commerce/cart/CartServiceTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/cart/CartServiceTest.java
@@ -1,0 +1,194 @@
+package com.spartafarmer.agri_commerce.cart;
+
+import com.spartafarmer.agri_commerce.common.enums.ProductStatus;
+import com.spartafarmer.agri_commerce.common.enums.ProductType;
+import com.spartafarmer.agri_commerce.common.enums.UserRole;
+import com.spartafarmer.agri_commerce.common.exception.CustomException;
+import com.spartafarmer.agri_commerce.common.exception.ErrorCode;
+import com.spartafarmer.agri_commerce.domain.cart.dto.CartAddRequest;
+import com.spartafarmer.agri_commerce.domain.cart.dto.CartAddResponse;
+import com.spartafarmer.agri_commerce.domain.cart.dto.CartResponse;
+import com.spartafarmer.agri_commerce.domain.cart.dto.CartUpdateRequest;
+import com.spartafarmer.agri_commerce.domain.cart.dto.CartUpdateResponse;
+import com.spartafarmer.agri_commerce.domain.cart.entity.Cart;
+import com.spartafarmer.agri_commerce.domain.cart.entity.CartItem;
+import com.spartafarmer.agri_commerce.domain.cart.repository.CartItemRepository;
+import com.spartafarmer.agri_commerce.domain.cart.repository.CartRepository;
+import com.spartafarmer.agri_commerce.domain.cart.service.CartService;
+import com.spartafarmer.agri_commerce.domain.product.entity.Product;
+import com.spartafarmer.agri_commerce.domain.product.repository.ProductRepository;
+import com.spartafarmer.agri_commerce.domain.user.entity.User;
+import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CartServiceTest {
+
+    @InjectMocks
+    private CartService cartService;
+
+    @Mock
+    private CartRepository cartRepository;
+
+    @Mock
+    private CartItemRepository cartItemRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    void 장바구니_상품추가_성공_신규상품() {
+        User user = 유저();
+        Product product = 상품("사과", 3000L, 2500L, 10, ProductStatus.ON_SALE);
+        Cart cart = Cart.create(user);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(productRepository.findById(1L)).willReturn(Optional.of(product));
+        given(cartRepository.findByUser(user)).willReturn(Optional.of(cart));
+        given(cartItemRepository.findByCartAndProduct(cart, product)).willReturn(Optional.empty());
+        given(cartItemRepository.save(any(CartItem.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        CartAddResponse response = cartService.addCart(1L, new CartAddRequest(1L, 2));
+
+        assertThat(response.productName()).isEqualTo("사과");
+        assertThat(response.price()).isEqualTo(2500L);
+        assertThat(response.quantity()).isEqualTo(2);
+        assertThat(response.totalPrice()).isEqualTo(5000L);
+    }
+
+    @Test
+    void 장바구니_상품추가_성공_기존상품이면_수량증가() {
+        User user = 유저();
+        Product product = 상품("사과", 3000L, 2500L, 10, ProductStatus.ON_SALE);
+        Cart cart = Cart.create(user);
+        CartItem cartItem = CartItem.create(cart, product, product.getSalePrice(), 2);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(productRepository.findById(1L)).willReturn(Optional.of(product));
+        given(cartRepository.findByUser(user)).willReturn(Optional.of(cart));
+        given(cartItemRepository.findByCartAndProduct(cart, product)).willReturn(Optional.of(cartItem));
+
+        CartAddResponse response = cartService.addCart(1L, new CartAddRequest(1L, 3));
+
+        assertThat(response.quantity()).isEqualTo(5);
+        assertThat(cartItem.getQuantity()).isEqualTo(5);
+    }
+
+    @Test
+    void 장바구니_상품추가_실패_재고초과() {
+        User user = 유저();
+        Product product = 상품("사과", 3000L, 2500L, 3, ProductStatus.ON_SALE);
+        Cart cart = Cart.create(user);
+        CartItem cartItem = CartItem.create(cart, product, product.getSalePrice(), 2);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(productRepository.findById(1L)).willReturn(Optional.of(product));
+        given(cartRepository.findByUser(user)).willReturn(Optional.of(cart));
+        given(cartItemRepository.findByCartAndProduct(cart, product)).willReturn(Optional.of(cartItem));
+
+        assertThatThrownBy(() -> cartService.addCart(1L, new CartAddRequest(1L, 2)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.OUT_OF_STOCK));
+    }
+
+    @Test
+    void 장바구니_조회_성공() {
+        User user = 유저();
+        Product product = 상품("감자", 4000L, 3000L, 20, ProductStatus.ON_SALE);
+        Cart cart = Cart.create(user);
+        CartItem.create(cart, product, product.getSalePrice(), 3);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(cartRepository.findByUserWithItems(user)).willReturn(Optional.of(cart));
+
+        CartResponse response = cartService.getCart(1L);
+
+        assertThat(response.cartItems()).hasSize(1);
+        assertThat(response.cartItems().get(0).productName()).isEqualTo("감자");
+        assertThat(response.totalPrice()).isEqualTo(9000L);
+        assertThat(response.isMinOrderAmountMet()).isFalse();
+
+        verify(cartRepository).findByUserWithItems(user);
+    }
+
+    @Test
+    void 장바구니_수량변경_성공() {
+        User user = 유저();
+        Product product = 상품("고구마", 6000L, 5000L, 10, ProductStatus.ON_SALE);
+        Cart cart = Cart.create(user);
+        CartItem cartItem = CartItem.create(cart, product, product.getSalePrice(), 2);
+
+        given(cartItemRepository.findByIdAndCart_User_Id(1L, 1L)).willReturn(Optional.of(cartItem));
+
+        CartUpdateResponse response = cartService.updateQuantity(1L, new CartUpdateRequest(4), 1L);
+
+        assertThat(response.quantity()).isEqualTo(4);
+        assertThat(response.totalPrice()).isEqualTo(20000L);
+        assertThat(cartItem.getQuantity()).isEqualTo(4);
+    }
+
+    @Test
+    void 장바구니_삭제_성공_소유자검증() {
+        User user = 유저();
+        Product product = 상품("당근", 3000L, 2500L, 10, ProductStatus.ON_SALE);
+        Cart cart = Cart.create(user);
+        CartItem cartItem = CartItem.create(cart, product, product.getSalePrice(), 2);
+
+        given(cartItemRepository.findByIdAndCart_User_Id(1L, 1L)).willReturn(Optional.of(cartItem));
+
+        cartService.deleteCartItem(1L, 1L);
+
+        assertThat(cart.getCartItems()).isEmpty();
+        verify(cartItemRepository).findByIdAndCart_User_Id(1L, 1L);
+    }
+
+    @Test
+    void 장바구니_삭제_실패_다른유저상품() {
+        given(cartItemRepository.findByIdAndCart_User_Id(1L, 2L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> cartService.deleteCartItem(1L, 2L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.CART_ITEM_NOT_FOUND));
+    }
+
+    private User 유저() {
+        return User.create(
+                "test@test.com",
+                "Password123",
+                "테스트유저",
+                User.formatPhone("01012345678"),
+                "서울",
+                UserRole.USER
+        );
+    }
+
+    private Product 상품(String name, Long normalPrice, Long salePrice, int stock, ProductStatus status) {
+        return Product.create(
+                name,
+                ProductType.NORMAL,
+                normalPrice,
+                salePrice,
+                null,
+                stock,
+                status,
+                name + ".jpg"
+        );
+    }
+}

--- a/src/test/java/com/spartafarmer/agri_commerce/order/OrderCreateServiceTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/order/OrderCreateServiceTest.java
@@ -17,6 +17,7 @@ import com.spartafarmer.agri_commerce.domain.order.entity.Order;
 import com.spartafarmer.agri_commerce.domain.order.repository.OrderRepository;
 import com.spartafarmer.agri_commerce.domain.order.service.OrderCreateService;
 import com.spartafarmer.agri_commerce.domain.product.entity.Product;
+import com.spartafarmer.agri_commerce.domain.product.repository.ProductRepository;
 import com.spartafarmer.agri_commerce.domain.user.entity.User;
 import com.spartafarmer.agri_commerce.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -30,8 +31,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,6 +52,9 @@ class OrderCreateServiceTest {
     @Mock
     private UserCouponRepository userCouponRepository;
 
+    @Mock
+    private ProductRepository productRepository;
+
     @Test
     void 주문생성_성공() {
         User user = 유저();
@@ -63,7 +66,13 @@ class OrderCreateServiceTest {
         CartItem.create(cart, product2, product2.getSalePrice(), 1);
 
         given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-        given(cartRepository.findByUser(user)).willReturn(Optional.of(cart));
+        given(cartRepository.findByUserWithItems(user)).willReturn(Optional.of(cart));
+        given(productRepository.decreaseStockAtomic(
+                any(),
+                anyInt(),
+                eq(ProductStatus.ON_SALE),
+                eq(ProductStatus.SOLD_OUT)
+        )).willReturn(1);
         given(orderRepository.save(any(Order.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         OrderCreateResponse result = orderCreateService.createOrder(1L, null);
@@ -73,8 +82,6 @@ class OrderCreateServiceTest {
         assertThat(result.finalPrice()).isEqualTo(22000L);
         assertThat(result.status()).isEqualTo("COMPLETED");
         assertThat(cart.getCartItems()).isEmpty();
-        assertThat(product1.getStock()).isEqualTo(9);
-        assertThat(product2.getStock()).isEqualTo(9);
     }
 
     @Test
@@ -83,7 +90,7 @@ class OrderCreateServiceTest {
         Cart cart = Cart.create(user);
 
         given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-        given(cartRepository.findByUser(user)).willReturn(Optional.of(cart));
+        given(cartRepository.findByUserWithItems(user)).willReturn(Optional.of(cart));
 
         assertThatThrownBy(() -> orderCreateService.createOrder(1L, null))
                 .isInstanceOf(CustomException.class)
@@ -100,7 +107,7 @@ class OrderCreateServiceTest {
         CartItem.create(cart, product, product.getSalePrice(), 1);
 
         given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-        given(cartRepository.findByUser(user)).willReturn(Optional.of(cart));
+        given(cartRepository.findByUserWithItems(user)).willReturn(Optional.of(cart));
 
         assertThatThrownBy(() -> orderCreateService.createOrder(1L, null))
                 .isInstanceOf(CustomException.class)
@@ -117,7 +124,7 @@ class OrderCreateServiceTest {
         CartItem.create(cart, specialProduct, specialProduct.getSalePrice(), 1);
 
         given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-        given(cartRepository.findByUser(user)).willReturn(Optional.of(cart));
+        given(cartRepository.findByUserWithItems(user)).willReturn(Optional.of(cart));
 
         assertThatThrownBy(() -> orderCreateService.createOrder(1L, 1L))
                 .isInstanceOf(CustomException.class)
@@ -145,8 +152,14 @@ class OrderCreateServiceTest {
         UserCoupon userCoupon = UserCoupon.issue(user, coupon, LocalDateTime.now());
 
         given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
-        given(cartRepository.findByUser(user)).willReturn(Optional.of(cart));
+        given(cartRepository.findByUserWithItems(user)).willReturn(Optional.of(cart));
         given(userCouponRepository.findByIdAndUserId(anyLong(), anyLong())).willReturn(Optional.of(userCoupon));
+        given(productRepository.decreaseStockAtomic(
+                any(),
+                anyInt(),
+                eq(ProductStatus.ON_SALE),
+                eq(ProductStatus.SOLD_OUT)
+        )).willReturn(1);
         given(orderRepository.save(any(Order.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         OrderCreateResponse result = orderCreateService.createOrder(1L, 1L);

--- a/src/test/java/com/spartafarmer/agri_commerce/order/OrderIntegrationTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/order/OrderIntegrationTest.java
@@ -43,7 +43,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-//
+@Tag("integration")
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
@@ -82,7 +82,6 @@ public class OrderIntegrationTest {
 
     @Test
     void 주문생성_성공() throws Exception {
-        // given
         Product product1 = 상품저장("사과", 15000L, 12000L, 10, ProductStatus.ON_SALE, null);
         Product product2 = 상품저장("배", 12000L, 10000L, 10, ProductStatus.ON_SALE, null);
 
@@ -90,10 +89,8 @@ public class OrderIntegrationTest {
         장바구니상품추가(cart, product1, 1);
         장바구니상품추가(cart, product2, 1);
 
-        // when
         ResultActions result = 주문요청(null);
 
-        // then
         result.andExpect(status().isCreated())
                 .andExpect(jsonPath("$.status").value(201))
                 .andExpect(jsonPath("$.message").value("주문 생성 성공"))
@@ -107,13 +104,14 @@ public class OrderIntegrationTest {
         assertThat(orders).hasSize(1);
         assertThat(orders.get(0).getStatus()).isEqualTo(OrderStatus.COMPLETED);
 
-        Product savedProduct1 = productRepository.findById(product1.getId()).orElseThrow();
-        Product savedProduct2 = productRepository.findById(product2.getId()).orElseThrow();
-        assertThat(savedProduct1.getStock()).isEqualTo(9);
-        assertThat(savedProduct2.getStock()).isEqualTo(9);
-
         entityManager.flush();
         entityManager.clear();
+
+        Product savedProduct1 = productRepository.findById(product1.getId()).orElseThrow();
+        Product savedProduct2 = productRepository.findById(product2.getId()).orElseThrow();
+
+        assertThat(savedProduct1.getStock()).isEqualTo(9);
+        assertThat(savedProduct2.getStock()).isEqualTo(9);
 
         Cart savedCart = cartRepository.findByUser(user).orElseThrow();
         assertThat(savedCart.getCartItems()).isEmpty();
@@ -121,7 +119,6 @@ public class OrderIntegrationTest {
 
     @Test
     void 주문생성_성공_쿠폰적용() throws Exception {
-        // given
         Product product1 = 상품저장("감자", 18000L, 15000L, 10, ProductStatus.ON_SALE, null);
         Product product2 = 상품저장("고구마", 12000L, 10000L, 10, ProductStatus.ON_SALE, null);
 
@@ -143,10 +140,8 @@ public class OrderIntegrationTest {
                 UserCoupon.issue(user, coupon, LocalDateTime.now())
         );
 
-        // when
         ResultActions result = 주문요청(userCoupon.getId());
 
-        // then
         result.andExpect(status().isCreated())
                 .andExpect(jsonPath("$.status").value(201))
                 .andExpect(jsonPath("$.message").value("주문 생성 성공"))
@@ -161,12 +156,8 @@ public class OrderIntegrationTest {
 
     @Test
     void 주문생성_실패_장바구니없음() throws Exception {
-        // given
-
-        // when
         ResultActions result = 주문요청(null);
 
-        // then
         result.andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.message").value("장바구니를 찾을 수 없습니다."))
@@ -175,16 +166,13 @@ public class OrderIntegrationTest {
 
     @Test
     void 주문생성_실패_최소주문금액미만() throws Exception {
-        // given
         Product product = 상품저장("양파", 10000L, 8000L, 10, ProductStatus.ON_SALE, null);
 
         Cart cart = 장바구니생성(user);
         장바구니상품추가(cart, product, 1);
 
-        // when
         ResultActions result = 주문요청(null);
 
-        // then
         result.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("최소 주문 금액은 20,000원 이상입니다."))
@@ -195,16 +183,13 @@ public class OrderIntegrationTest {
 
     @Test
     void 주문생성_실패_재고부족() throws Exception {
-        // given
         Product product = 상품저장("토마토", 15000L, 12000L, 1, ProductStatus.ON_SALE, null);
 
         Cart cart = 장바구니생성(user);
         장바구니상품추가(cart, product, 2);
 
-        // when
         ResultActions result = 주문요청(null);
 
-        // then
         result.andExpect(status().isConflict())
                 .andExpect(jsonPath("$.status").value(409))
                 .andExpect(jsonPath("$.message").value("재고가 부족합니다."))
@@ -215,16 +200,13 @@ public class OrderIntegrationTest {
 
     @Test
     void 주문생성_실패_품절상품() throws Exception {
-        // given
         Product product = 상품저장("품절 상품", 25000L, 22000L, 0, ProductStatus.SOLD_OUT, null);
 
         Cart cart = 장바구니생성(user);
         장바구니상품추가(cart, product, 1);
 
-        // when
         ResultActions result = 주문요청(null);
 
-        // then
         result.andExpect(status().isConflict())
                 .andExpect(jsonPath("$.status").value(409))
                 .andExpect(jsonPath("$.message").value("품절된 상품입니다."))
@@ -233,16 +215,13 @@ public class OrderIntegrationTest {
 
     @Test
     void 주문생성_실패_판매종료상품() throws Exception {
-        // given
         Product product = 상품저장("판매종료 상품", 25000L, 22000L, 10, ProductStatus.SALE_ENDED, null);
 
         Cart cart = 장바구니생성(user);
         장바구니상품추가(cart, product, 1);
 
-        // when
         ResultActions result = 주문요청(null);
 
-        // then
         result.andExpect(status().isConflict())
                 .andExpect(jsonPath("$.status").value(409))
                 .andExpect(jsonPath("$.message").value("판매 종료된 상품입니다."))
@@ -251,16 +230,13 @@ public class OrderIntegrationTest {
 
     @Test
     void 주문생성_실패_판매전상품() throws Exception {
-        // given
         Product product = 상품저장("판매전 상품", 25000L, 22000L, 10, ProductStatus.READY, null);
 
         Cart cart = 장바구니생성(user);
         장바구니상품추가(cart, product, 1);
 
-        // when
         ResultActions result = 주문요청(null);
 
-        // then
         result.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("현재 판매 중인 상품이 아닙니다."))
@@ -269,7 +245,6 @@ public class OrderIntegrationTest {
 
     @Test
     void 주문생성_실패_쿠폰없음() throws Exception {
-        // given
         Product product1 = 상품저장("사과", 18000L, 15000L, 10, ProductStatus.ON_SALE, null);
         Product product2 = 상품저장("배", 12000L, 10000L, 10, ProductStatus.ON_SALE, null);
 
@@ -277,10 +252,8 @@ public class OrderIntegrationTest {
         장바구니상품추가(cart, product1, 1);
         장바구니상품추가(cart, product2, 1);
 
-        // when
         ResultActions result = 주문요청(9999L);
 
-        // then
         result.andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.message").value("쿠폰을 찾을 수 없습니다."))
@@ -289,7 +262,6 @@ public class OrderIntegrationTest {
 
     @Test
     void 주문생성_실패_이미사용한쿠폰() throws Exception {
-        // given
         Product product1 = 상품저장("감자", 18000L, 15000L, 10, ProductStatus.ON_SALE, null);
         Product product2 = 상품저장("고구마", 12000L, 10000L, 10, ProductStatus.ON_SALE, null);
 
@@ -312,10 +284,8 @@ public class OrderIntegrationTest {
         );
         userCoupon.use();
 
-        // when
         ResultActions result = 주문요청(userCoupon.getId());
 
-        // then
         result.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("이미 사용된 쿠폰입니다."))
@@ -324,7 +294,6 @@ public class OrderIntegrationTest {
 
     @Test
     void 주문생성_실패_만료된쿠폰() throws Exception {
-        // given
         Product product1 = 상품저장("감자", 18000L, 15000L, 10, ProductStatus.ON_SALE, null);
         Product product2 = 상품저장("고구마", 12000L, 10000L, 10, ProductStatus.ON_SALE, null);
 
@@ -346,10 +315,8 @@ public class OrderIntegrationTest {
                 UserCoupon.issue(user, coupon, LocalDateTime.now().minusDays(10))
         );
 
-        // when
         ResultActions result = 주문요청(expiredUserCoupon.getId());
 
-        // then
         result.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("만료된 쿠폰입니다."))
@@ -358,7 +325,6 @@ public class OrderIntegrationTest {
 
     @Test
     void 주문생성_실패_특가상품포함_쿠폰사용불가() throws Exception {
-        // given
         Product specialProduct = 상품저장("특가 딸기", 25000L, 20000L, 10, ProductStatus.ON_SALE, 12000L);
 
         Cart cart = 장바구니생성(user);
@@ -378,10 +344,8 @@ public class OrderIntegrationTest {
                 UserCoupon.issue(user, coupon, LocalDateTime.now())
         );
 
-        // when
         ResultActions result = 주문요청(userCoupon.getId());
 
-        // then
         result.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("특가 상품이 포함된 주문에는 쿠폰을 사용할 수 없습니다."))
@@ -390,7 +354,6 @@ public class OrderIntegrationTest {
 
     @Test
     void 주문목록조회_성공() throws Exception {
-        // given
         Product product1 = 상품저장("사과", 15000L, 12000L, 10, ProductStatus.ON_SALE, null);
         Product product2 = 상품저장("배", 12000L, 10000L, 10, ProductStatus.ON_SALE, null);
 
@@ -400,11 +363,9 @@ public class OrderIntegrationTest {
 
         주문요청(null).andExpect(status().isCreated());
 
-        // when
         ResultActions result = mockMvc.perform(get("/api/orders")
                 .header("Authorization", bearerToken()));
 
-        // then
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.message").value("주문 목록 조회 성공"))

--- a/src/test/java/com/spartafarmer/agri_commerce/order/OrderIntegrationTest.java
+++ b/src/test/java/com/spartafarmer/agri_commerce/order/OrderIntegrationTest.java
@@ -43,7 +43,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Tag("integration")
+//
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional


### PR DESCRIPTION
**📌 작업 내용**
장바구니 조회 성능과 주문 생성 시 재고 차감 안정성을 개선
리펙토링에 맞춰서 테스트코드 수정

**🔗 관련 이슈**- close #181 


**🧩 변경 사항**
#### 장바구니

- 장바구니 조회 시 N+1 문제 개선
  - `CartItem`, `Product`를 함께 조회하도록 fetch join 적용
  - 빈 장바구니도 조회 가능하도록 `LEFT JOIN FETCH` 사용
- 동일 상품 중복 담기 처리 확인
  - 기존 CartItem이 있으면 새로 생성하지 않고 수량 증가
- 장바구니 상품 삭제 시 사용자 소유 여부 검증 확인
  - `cartItemId + userId` 기준으로 조회하여 타 유저 항목 삭제 방지

#### 주문

- 주문 생성 시 사용자 검증 로직 확인
  - `userId` 기반 사용자 조회 후 없으면 예외 처리
- 주문 생성 시 장바구니 조회도 fetch join 사용하도록 변경
  - 주문 과정에서 CartItem/Product 접근 시 추가 쿼리 발생 방지
- 재고 차감 로직을 DB 원자적 update 방식으로 변경
  - 기존 엔티티 메서드 기반 차감에서 `stock >= quantity` 조건부 update로 변경
  - 동시 요청 시 음수 재고 발생 가능성 방지
- 재고가 0이 되는 경우 상품 상태를 `SOLD_OUT`으로 함께 변경
- 재고 차감 실패 시 `OUT_OF_STOCK` 예외 처리

#### 테스트

- `OrderCreateServiceTest` 수정
  - `findByUserWithItems()` 사용 흐름 반영
- `OrderIntegrationTest` 수정
  - 재고 차감 후 영속성 컨텍스트 초기화 후 DB 상태 검증
- `CartServiceTest` 신규 추가
  - 장바구니 상품 추가
  - 동일 상품 중복 담기 시 수량 증가
  - 장바구니 조회
  - 수량 변경
  - 상품 삭제 및 소유자 검증
- `CartControllerTest` 신규 추가
  - 장바구니 추가/조회/수량 변경/삭제 API 응답 검증
- `CartIntegrationTest` 보강
  - 동일 상품 중복 담기 시 수량 증가 검증
  - 다른 유저 장바구니 상품 삭제 실패 검증


**🧪 테스트**
- [ ] Postman 1차 테스트 완료

- [ ] 단위 테스트 완료 (해당 시)


**🔥 리뷰 요청** 
- 주문 생성 시 재고 차감을 Redis 락과 DB 조건부 update를 함께 사용하는 구조로 변경